### PR TITLE
ci: improve Browser Use sync and uv-based CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: lint
 
-# Cancel in-progress runs when a new commit is pushed to the same branch/PR
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -10,9 +12,9 @@ on:
     branches:
       - main
       - stable
-      - 'releases/**'
+      - "releases/**"
     tags:
-      - '*'
+      - "*"
   pull_request:
   workflow_dispatch:
 
@@ -22,21 +24,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      - run: uv run ruff check --no-fix --select PLE
+      - run: uv sync --frozen --extra dev
+      - run: uv run --no-sync ruff check --no-fix --select PLE
 
   lint-style:
     name: code-style
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      - run: uv python install 3.11
-      - run: uv sync --dev --all-extras --python 3.11
+      - run: uv sync --frozen --extra dev
       - run: uv run --no-sync pre-commit run --all-files --show-diff-on-failure
 
   lint-typecheck:
@@ -44,8 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      - run: uv sync --dev --all-extras  # install extras for examples to avoid pyright missing imports errors-
+      - run: uv sync --frozen --extra dev
       - run: uv run --no-sync pyright

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -2,17 +2,31 @@ name: Sync upstream browser-use
 
 on:
   schedule:
-    # Run daily at 06:00 UTC (11pm PT)
-    - cron: '0 6 * * *'
-  workflow_dispatch: # Allow manual trigger
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Upstream ref to sync from"
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - main
 
 permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: sync-upstream-browser-use
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      BASE_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,88 +34,175 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Add upstream remote
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install "$(cat .python-version)"
+
+      - name: Install project dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Fetch upstream refs
         run: |
           git remote add upstream https://github.com/browser-use/browser-use.git 2>/dev/null || true
-          git fetch upstream main
+          git fetch upstream main stable --tags --prune
 
-      - name: Check for new commits
-        id: check
+      - name: Compute upstream status
+        id: status
+        run: uv run --no-sync python scripts/browser_use_upstream_status.py --github-output "$GITHUB_OUTPUT"
+
+      - name: Select sync target
+        id: target
+        env:
+          INPUT_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || '' }}
+          BEHIND_STABLE: ${{ steps.status.outputs.behind_upstream_stable }}
+          BEHIND_MAIN: ${{ steps.status.outputs.behind_upstream_main }}
+          LATEST_RELEASE_TAG: ${{ steps.status.outputs.latest_release_tag }}
+          UPSTREAM_STABLE_SHA: ${{ steps.status.outputs.upstream_stable_sha }}
+          UPSTREAM_MAIN_SHA: ${{ steps.status.outputs.upstream_main_sha }}
         run: |
-          BEHIND=$(git rev-list --count HEAD..upstream/main)
-          echo "behind=$BEHIND" >> $GITHUB_OUTPUT
-          echo "Commits behind upstream: $BEHIND"
-          if [ "$BEHIND" -eq 0 ]; then
-            echo "Already up to date with upstream"
+          if [ -n "$INPUT_TARGET" ]; then
+            TARGET_NAME="$INPUT_TARGET"
           else
-            echo "New upstream commits:"
-            git log --oneline HEAD..upstream/main
+            TARGET_NAME="stable"
           fi
 
-      - name: Create sync branch and merge
-        if: steps.check.outputs.behind != '0'
+          case "$TARGET_NAME" in
+            stable)
+              TARGET_REF="upstream/stable"
+              TARGET_SHA="$UPSTREAM_STABLE_SHA"
+              TARGET_VERSION="$LATEST_RELEASE_TAG"
+              BEHIND_COUNT="$BEHIND_STABLE"
+              SYNC_BRANCH="sync/browser-use-stable"
+              ;;
+            main)
+              TARGET_REF="upstream/main"
+              TARGET_SHA="$UPSTREAM_MAIN_SHA"
+              TARGET_VERSION="$(git rev-parse --short "$UPSTREAM_MAIN_SHA")"
+              BEHIND_COUNT="$BEHIND_MAIN"
+              SYNC_BRANCH="sync/browser-use-main"
+              ;;
+            *)
+              echo "Unsupported target: $TARGET_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "target_name=$TARGET_NAME"
+            echo "target_ref=$TARGET_REF"
+            echo "target_sha=$TARGET_SHA"
+            echo "target_version=$TARGET_VERSION"
+            echo "behind_count=$BEHIND_COUNT"
+            echo "sync_branch=$SYNC_BRANCH"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$BEHIND_COUNT" = "0" ]; then
+            echo "needs_sync=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Browser Use sync"
+              echo ""
+              echo "No sync needed for \`$TARGET_REF\`."
+              echo ""
+              echo "- Current release tag: \`${{ steps.status.outputs.current_tag }}\`"
+              echo "- Latest upstream release tag: \`${{ steps.status.outputs.latest_release_tag }}\`"
+              echo "- Behind upstream/stable: \`${BEHIND_STABLE}\`"
+              echo "- Behind upstream/main: \`${BEHIND_MAIN}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "needs_sync=true" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git author
+        if: steps.target.outputs.needs_sync == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge upstream into sync branch
+        if: steps.target.outputs.needs_sync == 'true'
         id: merge
+        env:
+          SYNC_BRANCH: ${{ steps.target.outputs.sync_branch }}
+          TARGET_REF: ${{ steps.target.outputs.target_ref }}
+          TARGET_VERSION: ${{ steps.target.outputs.target_version }}
+          TARGET_NAME: ${{ steps.target.outputs.target_name }}
         run: |
-          BRANCH="sync/browser-use-$(date +%Y-%m-%d)"
-          git checkout -b "$BRANCH"
+          git fetch origin "$BASE_BRANCH"
+          git checkout -B "$SYNC_BRANCH" "origin/$BASE_BRANCH"
 
-          # Attempt merge
-          if git merge upstream/main --no-edit; then
-            echo "conflict=false" >> $GITHUB_OUTPUT
+          set +e
+          git merge "$TARGET_REF" --no-ff -m "sync(browser-use): merge upstream/$TARGET_NAME $TARGET_VERSION"
+          MERGE_EXIT=$?
+          set -e
+
+          if [ "$MERGE_EXIT" -eq 0 ]; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
           else
-            # If conflict, commit the conflict markers for manual resolution
             git add -A
-            git commit -m "sync(browser-use): merge upstream with conflicts
-
-          This merge has conflicts that need manual resolution.
-          Our custom patches in browser_use/:
-          - agent/service.py (coordinate clicking pattern)
-          - llm/google/chat.py (verified models list)
-          - tokens/custom_pricing.py (model pricing)
-          - tokens/mappings.py (model mappings)"
-            echo "conflict=true" >> $GITHUB_OUTPUT
+            git commit -m "sync(browser-use): merge upstream/$TARGET_NAME $TARGET_VERSION with conflicts"
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
           fi
 
-          git push origin "$BRANCH"
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          git push origin "$SYNC_BRANCH" --force-with-lease
 
-      - name: Create PR
-        if: steps.check.outputs.behind != '0'
+      - name: Create or update pull request
+        if: steps.target.outputs.needs_sync == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BEHIND: ${{ steps.check.outputs.behind }}
-          BRANCH: ${{ steps.merge.outputs.branch }}
-          HAS_CONFLICT: ${{ steps.merge.outputs.conflict }}
+          BASE_BRANCH: ${{ env.BASE_BRANCH }}
+          SYNC_BRANCH: ${{ steps.target.outputs.sync_branch }}
+          TARGET_NAME: ${{ steps.target.outputs.target_name }}
+          TARGET_REF: ${{ steps.target.outputs.target_ref }}
+          TARGET_SHA: ${{ steps.target.outputs.target_sha }}
+          TARGET_VERSION: ${{ steps.target.outputs.target_version }}
+          BEHIND_COUNT: ${{ steps.target.outputs.behind_count }}
+          CONFLICT: ${{ steps.merge.outputs.conflict }}
+          CURRENT_TAG: ${{ steps.status.outputs.current_tag }}
+          LATEST_RELEASE_TAG: ${{ steps.status.outputs.latest_release_tag }}
+          BEHIND_STABLE: ${{ steps.status.outputs.behind_upstream_stable }}
+          BEHIND_MAIN: ${{ steps.status.outputs.behind_upstream_main }}
         run: |
-          if [ "$HAS_CONFLICT" = "true" ]; then
-            TITLE="sync(browser-use): $BEHIND new commits (HAS CONFLICTS)"
-            LABEL="--label sync --label conflicts"
+          if [ "$TARGET_NAME" = "stable" ]; then
+            TITLE="sync(browser-use): update to $TARGET_VERSION"
           else
-            TITLE="sync(browser-use): $BEHIND new commits"
-            LABEL="--label sync"
+            TITLE="sync(browser-use): merge upstream main ($BEHIND_COUNT commits)"
           fi
 
-          BODY="## Upstream Sync
+          BODY=$(cat <<EOF
+          ## Upstream Browser Use sync
 
-          **$BEHIND new commit(s)** from [browser-use/browser-use](https://github.com/browser-use/browser-use)
+          - Target ref: \`$TARGET_REF\`
+          - Target SHA: \`$TARGET_SHA\`
+          - Current release tag in this fork: \`${CURRENT_TAG:-unknown}\`
+          - Latest upstream release tag: \`${LATEST_RELEASE_TAG:-unknown}\`
+          - Behind upstream/stable before sync: \`$BEHIND_STABLE\`
+          - Behind upstream/main before sync: \`$BEHIND_MAIN\`
 
-          ### Changes
-          $(git log --oneline HEAD~${BEHIND}..HEAD | head -20)
+          This repository vendors \`browser_use/\` in-tree, so upstream updates are merged into a dedicated sync branch instead of bumping a package version.
 
-          ### Our custom patches (check for conflicts)
-          - \`browser_use/agent/service.py\` — coordinate clicking for Gemini 3
-          - \`browser_use/llm/google/chat.py\` — verified models list
-          - \`browser_use/tokens/custom_pricing.py\` — custom model pricing
-          - \`browser_use/tokens/mappings.py\` — model name mappings
+          $(if [ "$CONFLICT" = "true" ]; then
+            echo "> Merge conflicts were committed to this branch for manual resolution."
+          fi)
+          EOF
+          )
 
-          $([ "$HAS_CONFLICT" = "true" ] && echo '### :warning: Merge conflicts detected — manual resolution required')
+          PR_NUMBER=$(gh pr list --head "$SYNC_BRANCH" --base "$BASE_BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr edit "$PR_NUMBER" --title "$TITLE" --body "$BODY"
+          else
+            gh pr create --title "$TITLE" --body "$BODY" --base "$BASE_BRANCH" --head "$SYNC_BRANCH"
+          fi
 
-          ---
-          *Auto-generated by sync-upstream workflow*"
-
-          gh pr create \
-            --title "$TITLE" \
-            --body "$BODY" \
-            --base main \
-            --head "$BRANCH" \
-            $LABEL
+          {
+            echo "## Browser Use sync"
+            echo ""
+            echo "- Target ref: \`$TARGET_REF\`"
+            echo "- Target SHA: \`$TARGET_SHA\`"
+            echo "- Sync branch: \`$SYNC_BRANCH\`"
+            echo "- Conflicts committed: \`$CONFLICT\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,9 @@
 name: test
 permissions:
   actions: read
-  contents: write
-  pull-requests: write  # Allow writing comments on PRs
-  issues: write         # Allow writing comments on issues
-  statuses: write       # Allow writing statuses on PRs
-  discussions: write
+  contents: read
+  pull-requests: write
+  issues: write
 
 # Cancel in-progress runs when a new commit is pushed to the same branch/PR
 concurrency:
@@ -29,7 +27,15 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
       - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install project dependencies
+        run: uv sync --frozen --extra dev
 
       - name: Get week number for cache key
         id: week
@@ -41,13 +47,13 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ steps.week.outputs.number }}
+          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ hashFiles('uv.lock', '.python-version') }}-${{ steps.week.outputs.number }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-chromium-
 
       - name: Install Chromium if not cached
         if: steps.cache-chromium.outputs.cache-hit != 'true'
-        run: uvx playwright install chromium --with-deps --no-shell
+        run: uv run --no-sync playwright install chromium --with-deps --no-shell
 
   find_tests:
     runs-on: ubuntu-latest
@@ -81,7 +87,7 @@ jobs:
   tests:
     needs: [setup-chromium, find_tests]
     runs-on: ubuntu-latest
-    timeout-minutes: 4  # Reduced timeout - tests should complete quickly or retry
+    timeout-minutes: 8
     env:
       IN_DOCKER: 'True'
       ANONYMIZED_TELEMETRY: 'false'
@@ -96,6 +102,7 @@ jobs:
       BROWSER_USE_API_KEY: ${{ secrets.BROWSER_USE_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
     strategy:
+      fail-fast: false
       matrix:
         test_filename: ${{ fromJson(needs.find_tests.outputs.TEST_FILENAMES || '["FAILED_TO_DISCOVER_TESTS"]') }}
         # autodiscovers all the files in tests/ci/test_*.py
@@ -114,10 +121,12 @@ jobs:
           fi
 
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-          activate-environment: true
 
       - name: Cache uv packages and venv
         uses: actions/cache@v4
@@ -125,11 +134,11 @@ jobs:
           path: |
             ~/.cache/uv
             .venv
-          key: ${{ runner.os }}-uv-venv-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-uv-venv-${{ hashFiles('uv.lock', '.python-version') }}
           restore-keys: |
             ${{ runner.os }}-uv-venv-
 
-      - run: uv sync --dev --all-extras
+      - run: uv sync --frozen --extra dev
 
       - name: Get week number for cache key
         id: week
@@ -141,20 +150,20 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ steps.week.outputs.number }}
+          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ hashFiles('uv.lock', '.python-version') }}-${{ steps.week.outputs.number }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-chromium-
 
       - name: Install Chromium browser if not cached
         if: steps.cache-chromium.outputs.cache-hit != 'true'
-        run: uvx playwright install chromium --with-deps --no-shell
+        run: uv run --no-sync playwright install chromium --with-deps --no-shell
 
       - name: Cache browser-use extensions
         uses: actions/cache@v4
         with:
           path: |
             ~/.config/browseruse/extensions
-          key: ${{ runner.os }}-browseruse-extensions-${{ hashFiles('browser_use/browser/profile.py') }}
+          key: ${{ runner.os }}-browseruse-extensions-${{ hashFiles('browser_use/browser/profile.py', 'uv.lock') }}
           restore-keys: |
             ${{ runner.os }}-browseruse-extensions-
 
@@ -176,10 +185,10 @@ jobs:
         if: steps.check-file.outputs.exists == 'true'
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 4
-          max_attempts: 1
+          timeout_minutes: 6
+          max_attempts: 2
           retry_on: error
-          command: pytest "tests/ci/${{ matrix.test_filename }}.py"
+          command: uv run --no-sync pytest "tests/ci/${{ matrix.test_filename }}.py"
 
   evaluate-tasks:
     needs: setup-chromium
@@ -198,10 +207,12 @@ jobs:
       BROWSER_USE_API_KEY: ${{ secrets.BROWSER_USE_API_KEY }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-          activate-environment: true
 
       - name: Cache uv packages and venv
         uses: actions/cache@v4
@@ -209,11 +220,11 @@ jobs:
           path: |
             ~/.cache/uv
             .venv
-          key: ${{ runner.os }}-uv-venv-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-uv-venv-${{ hashFiles('uv.lock', '.python-version') }}
           restore-keys: |
             ${{ runner.os }}-uv-venv-
 
-      - run: uv sync --dev --all-extras
+      - run: uv sync --frozen --extra dev
 
       - name: Get week number for cache key
         id: week
@@ -225,20 +236,20 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ steps.week.outputs.number }}
+          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ hashFiles('uv.lock', '.python-version') }}-${{ steps.week.outputs.number }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-chromium-
 
       - name: Install Chromium browser if not cached
         if: steps.cache-chromium.outputs.cache-hit != 'true'
-        run: uvx playwright install chromium --with-deps --no-shell
+        run: uv run --no-sync playwright install chromium --with-deps --no-shell
 
       - name: Cache browser-use extensions
         uses: actions/cache@v4
         with:
           path: |
             ~/.config/browseruse/extensions
-          key: ${{ runner.os }}-browseruse-extensions-${{ hashFiles('browser_use/browser/profile.py') }}
+          key: ${{ runner.os }}-browseruse-extensions-${{ hashFiles('browser_use/browser/profile.py', 'uv.lock') }}
           restore-keys: |
             ${{ runner.os }}-browseruse-extensions-
 
@@ -246,11 +257,11 @@ jobs:
         id: eval
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 4
-          max_attempts: 1
+          timeout_minutes: 6
+          max_attempts: 2
           retry_on: error
           command: |
-            python tests/ci/evaluate_tasks.py > result.txt
+            uv run --no-sync python tests/ci/evaluate_tasks.py > result.txt
             cat result.txt
             echo "PASSED=$(grep '^PASSED=' result.txt | cut -d= -f2)" >> $GITHUB_ENV
             echo "TOTAL=$(grep '^TOTAL=' result.txt | cut -d= -f2)" >> $GITHUB_ENV

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.12
 
 repos:
   - repo: https://github.com/asottile/yesqa
@@ -18,7 +18,7 @@ repos:
     rev: v3.20.0
     hooks:
       - id: pyupgrade
-        args: [--py311-plus]
+        args: [--py312-plus]
 
   # - repo: https://github.com/asottile/add-trailing-comma
   #   rev: v3.1.0
@@ -33,10 +33,13 @@ repos:
       - id: ruff-format
       # see pyproject.toml for more details on ruff config
 
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.404
+  - repo: local
     hooks:
-    - id: pyright
+      - id: pyright
+        name: pyright
+        entry: uv run --no-sync pyright
+        language: system
+        types_or: [python]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,12 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "pre-commit>=4.2",
+    "pyright>=1.1.404",
     "pytest>=8.3",
     "pytest-asyncio>=0.25",
+    "pytest-httpserver>=1.1",
+    "pytest-xdist>=3.6",
     "ruff>=0.9",
 ]
 

--- a/scripts/browser_use_upstream_status.py
+++ b/scripts/browser_use_upstream_status.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+SEMVER_TAG_MATCH = "[0-9]*"
+
+
+class RefStatus(BaseModel):
+    ref: str
+    sha: str
+    ahead: int = Field(ge=0)
+    behind: int = Field(ge=0)
+    latest_tag: str | None = None
+
+
+class UpstreamStatus(BaseModel):
+    repo_root: str
+    current_sha: str
+    current_tag: str | None = None
+    latest_release_tag: str | None = None
+    on_latest_release: bool
+    upstream_stable: RefStatus
+    upstream_main: RefStatus
+
+
+def run_git(repo_root: Path, *args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def try_git(repo_root: Path, *args: str) -> str | None:
+    try:
+        value = run_git(repo_root, *args)
+    except subprocess.CalledProcessError:
+        return None
+    return value or None
+
+
+def build_ref_status(repo_root: Path, ref: str) -> RefStatus:
+    sha = run_git(repo_root, "rev-parse", ref)
+    ahead_str, behind_str = run_git(
+        repo_root,
+        "rev-list",
+        "--left-right",
+        "--count",
+        f"HEAD...{ref}",
+    ).split()
+    latest_tag = try_git(repo_root, "describe", "--tags", "--abbrev=0", "--match", SEMVER_TAG_MATCH, ref)
+    return RefStatus(
+        ref=ref,
+        sha=sha,
+        ahead=int(ahead_str),
+        behind=int(behind_str),
+        latest_tag=latest_tag,
+    )
+
+
+def build_status(repo_root: Path) -> UpstreamStatus:
+    current_sha = run_git(repo_root, "rev-parse", "HEAD")
+    current_tag = try_git(repo_root, "describe", "--tags", "--abbrev=0", "--match", SEMVER_TAG_MATCH, "HEAD")
+    upstream_stable = build_ref_status(repo_root, "upstream/stable")
+    upstream_main = build_ref_status(repo_root, "upstream/main")
+    latest_release_tag = upstream_stable.latest_tag
+
+    return UpstreamStatus(
+        repo_root=str(repo_root),
+        current_sha=current_sha,
+        current_tag=current_tag,
+        latest_release_tag=latest_release_tag,
+        on_latest_release=current_tag is not None and current_tag == latest_release_tag and upstream_stable.behind == 0,
+        upstream_stable=upstream_stable,
+        upstream_main=upstream_main,
+    )
+
+
+def format_summary(status: UpstreamStatus) -> str:
+    lines = [
+        f"Repository: {status.repo_root}",
+        f"Current HEAD: {status.current_sha}",
+        f"Current Browser Use release tag: {status.current_tag or 'unknown'}",
+        f"Latest upstream release tag: {status.latest_release_tag or 'unknown'}",
+        f"On latest upstream release: {'yes' if status.on_latest_release else 'no'}",
+        "",
+        "Upstream stable:",
+        f"  ref: {status.upstream_stable.ref}",
+        f"  sha: {status.upstream_stable.sha}",
+        f"  ahead: {status.upstream_stable.ahead}",
+        f"  behind: {status.upstream_stable.behind}",
+        f"  tag: {status.upstream_stable.latest_tag or 'unknown'}",
+        "",
+        "Upstream main:",
+        f"  ref: {status.upstream_main.ref}",
+        f"  sha: {status.upstream_main.sha}",
+        f"  ahead: {status.upstream_main.ahead}",
+        f"  behind: {status.upstream_main.behind}",
+        f"  tag: {status.upstream_main.latest_tag or 'unknown'}",
+    ]
+    return "\n".join(lines)
+
+
+def write_github_outputs(output_path: Path, status: UpstreamStatus) -> None:
+    outputs = {
+        "current_sha": status.current_sha,
+        "current_tag": status.current_tag or "",
+        "latest_release_tag": status.latest_release_tag or "",
+        "on_latest_release": str(status.on_latest_release).lower(),
+        "ahead_upstream_stable": str(status.upstream_stable.ahead),
+        "behind_upstream_stable": str(status.upstream_stable.behind),
+        "ahead_upstream_main": str(status.upstream_main.ahead),
+        "behind_upstream_main": str(status.upstream_main.behind),
+        "upstream_stable_sha": status.upstream_stable.sha,
+        "upstream_main_sha": status.upstream_main.sha,
+    }
+    with output_path.open("a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Report how this fork tracks upstream browser-use.")
+    parser.add_argument(
+        "--repo-root",
+        default=Path(__file__).resolve().parents[1],
+        type=Path,
+        help="Path to the repository root.",
+    )
+    parser.add_argument(
+        "--fetch",
+        action="store_true",
+        help="Fetch upstream main, stable, and tags before computing status.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of a text summary.",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="Append computed values to the GitHub Actions output file.",
+    )
+    parser.add_argument(
+        "--fail-if-behind",
+        choices=["stable", "main"],
+        help="Exit non-zero when HEAD is behind the selected upstream ref.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+
+    if args.fetch:
+        run_git(repo_root, "fetch", "upstream", "main", "stable", "--tags", "--prune")
+
+    status = build_status(repo_root)
+
+    if args.github_output is not None:
+        write_github_outputs(args.github_output, status)
+
+    if args.json:
+        print(json.dumps(status.model_dump(mode="json"), indent=2, sort_keys=True))
+    else:
+        print(format_summary(status))
+
+    if args.fail_if_behind == "stable" and status.upstream_stable.behind > 0:
+        return 1
+    if args.fail_if_behind == "main" and status.upstream_main.behind > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a reusable Browser Use upstream status script so release and main-branch drift are easy to check
- switch sync automation to track upstream `stable` by default, with manual opt-in syncs from upstream `main`
- align lint/test workflows and local tooling around Python 3.12 and lockfile-based `uv` installs

## Context
At the time of this change, this repo is already on the latest Browser Use release tag (`0.12.1`), but it is still behind upstream `main` by 3 commits. This PR improves how we detect and manage that drift without treating the vendored `browser_use/` tree like a normal PyPI dependency bump.

## Validation
- `uv run python scripts/browser_use_upstream_status.py --json`
- `uv run pre-commit run --files .pre-commit-config.yaml pyproject.toml scripts/browser_use_upstream_status.py .github/workflows/sync-upstream.yml .github/workflows/lint.yml .github/workflows/test.yaml`
- `uv run pyright scripts/browser_use_upstream_status.py`
- `uv run pytest tests/ci/infrastructure/test_registry_action_parameter_injection.py -q`

## Note
Full repo-wide `pyright` still reports pre-existing errors outside this change set.