### PR TITLE
fix(jsonl+lifecycle): JSONL schema fix, lease protocol, keep_alive + HITL (S2+S3)

### DIFF
--- a/ghosthands/agent/factory.py
+++ b/ghosthands/agent/factory.py
@@ -190,11 +190,20 @@ async def run_job_agent(
     max_budget: float | None = None,
     on_status_update: Callable[..., Awaitable[None]] | None = None,
     allowed_domains: list[str] | None = None,
+    keep_alive: bool | None = None,
 ) -> dict[str, Any]:
     """Convenience wrapper: create an agent, run it, and return a result dict.
 
     This is the function the worker calls for each job.  It handles the
     full lifecycle: create agent -> run -> extract result -> close browser.
+
+    Parameters
+    ----------
+    keep_alive:
+            Controls browser cleanup after the agent finishes.
+            ``False`` — kill the browser process (EC2 worker path).
+            ``True`` or ``None`` — stop the event bus but leave the
+            browser open for human review / HITL.
 
     Returns
     -------
@@ -257,12 +266,16 @@ async def run_job_agent(
             "blocker": blocker,
         }
     finally:
-        # run_job_agent is the worker convenience wrapper — the worker has no human
-        # reviewer, so always kill the browser when the job finishes.  Callers that
-        # want the browser to stay open (e.g. for HITL or manual review) should use
-        # create_job_agent() directly and manage the lifecycle themselves.
+        # Respect the keep_alive parameter for browser cleanup.
+        # keep_alive=False (EC2 worker): kill the browser process.
+        # keep_alive=True or None (Desktop/HITL): stop event bus but
+        # leave the browser open for human review.
         if agent.browser_session is not None:
             try:
-                await agent.browser_session.kill()
+                if keep_alive is False:
+                    await agent.browser_session.kill()
+                else:
+                    # keep_alive=True or None: stop event bus but leave browser open
+                    await agent.browser_session.event_bus.stop(clear=False, timeout=1.0)
             except Exception:
                 pass

--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -37,6 +37,7 @@ import json
 import logging
 import os
 import sys
+import uuid
 from pathlib import Path
 
 # Force unbuffered I/O for reliable JSONL streaming
@@ -149,11 +150,24 @@ def _load_profile(args: argparse.Namespace) -> dict:
 async def run_agent_jsonl(args: argparse.Namespace) -> None:
     """Run the agent with JSONL event output on stdout."""
     from ghosthands.output.jsonl import (
+        emit_browser_ready,
         emit_cost,
         emit_done,
         emit_error,
+        emit_handshake,
+        emit_lease_acquired,
+        emit_lease_released,
         emit_status,
     )
+
+    # -- Lease ID resolution ---------------------------------------------------
+    lease_id = args.lease_id or str(uuid.uuid4())
+
+    # -- Protocol handshake (must be the very first event) ----------------------
+    emit_handshake()
+
+    # -- Lease acquired --------------------------------------------------------
+    emit_lease_acquired(lease_id, job_id=args.job_id)
 
     emit_status("Hand-X engine initialized", job_id=args.job_id)
 
@@ -262,8 +276,18 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
     )
 
     # -- Step hooks for live JSONL events -----------------------------------
+    _browser_ready_emitted = False
+
     async def _on_step_start(ag: Agent) -> None:
+        nonlocal _browser_ready_emitted
         await install_same_tab_guard(ag)
+
+        # Emit browser_ready once, on the first step (browser is now live)
+        if not _browser_ready_emitted:
+            _browser_ready_emitted = True
+            cdp_url = getattr(ag.browser_session, "cdp_url", "") or ""
+            emit_browser_ready(cdp_url)
+
         step = ag.state.n_steps
         goal = ""
         if ag.state.last_model_output:
@@ -332,23 +356,26 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
                 message="Application filled -- browser open for review",
                 fields_filled=total_steps,
                 job_id=args.job_id,
-                lease_id=args.lease_id,
+                lease_id=lease_id,
                 result_data=result_data,
             )
-            await _wait_for_review_command(browser, args.job_id, args.lease_id)
+            await _wait_for_review_command(browser, args.job_id, lease_id)
+            emit_lease_released(lease_id, reason="completed")
         else:
             emit_done(
                 success=False,
                 message=blocker or final_result or "Agent did not complete successfully",
                 job_id=args.job_id,
-                lease_id=args.lease_id,
+                lease_id=lease_id,
                 result_data=result_data,
             )
+            emit_lease_released(lease_id, reason="failed")
             await browser.close()
             sys.exit(1)
 
     except Exception as e:
         emit_error(str(e), fatal=True, job_id=args.job_id)
+        emit_lease_released(lease_id, reason="error")
         with contextlib.suppress(Exception):
             await browser.close()
         sys.exit(1)

--- a/ghosthands/output/field_events.py
+++ b/ghosthands/output/field_events.py
@@ -64,7 +64,7 @@ def install_jsonl_callback() -> None:
             else:
                 emit_field_failed(
                     field=result.name,
-                    error=result.error or "unknown error",
+                    reason=result.error or "unknown error",
                 )
 
             # Emit cumulative progress after each field

--- a/ghosthands/output/jsonl.py
+++ b/ghosthands/output/jsonl.py
@@ -66,7 +66,7 @@ def emit_event(event_type: str, **kwargs: Any) -> None:
     to keep the wire format compact.
     """
     event: dict[str, Any] = {
-        "type": event_type,
+        "event": event_type,
         "timestamp": int(time.time() * 1000),
     }
     for key, value in kwargs.items():
@@ -110,10 +110,10 @@ def emit_field_filled(
 
 def emit_field_failed(
     field: str,
-    error: str,
+    reason: str,
 ) -> None:
     """Emit when a field fill attempt fails."""
-    emit_event("field_failed", field=field, error=error)
+    emit_event("field_failed", field=field, reason=reason)
 
 
 def emit_progress(
@@ -121,9 +121,18 @@ def emit_progress(
     total: int,
     *,
     round: int = 1,
+    description: str = "",
 ) -> None:
     """Emit a progress snapshot (fields filled so far)."""
-    emit_event("progress", filled=filled, total=total, round=round)
+    emit_event(
+        "progress",
+        filled=filled,
+        total=total,
+        step=filled,
+        maxSteps=total,
+        description=description or None,
+        round=round,
+    )
 
 
 def emit_done(
@@ -175,3 +184,32 @@ def emit_cost(
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
     )
+
+
+# -- Lease protocol events (S2) -----------------------------------------------
+
+
+def emit_handshake(protocol_version: int = 2) -> None:
+    """Emit protocol handshake as the very first event."""
+    emit_event("handshake", protocol_version=protocol_version)
+
+
+def emit_browser_ready(cdp_url: str) -> None:
+    """Emit when the browser is connected and CDP is available."""
+    emit_event("browser_ready", cdpUrl=cdp_url)
+
+
+def emit_lease_acquired(lease_id: str, job_id: str = "") -> None:
+    """Emit when a lease is acquired from the Desktop app."""
+    emit_event("lease_acquired", leaseId=lease_id, jobId=job_id or None)
+
+
+def emit_lease_released(lease_id: str, reason: str = "completed") -> None:
+    """Emit when a lease is released (agent done or cancelled)."""
+    emit_event("lease_released", leaseId=lease_id, reason=reason)
+
+
+def emit_lease_heartbeat(lease_id: str) -> None:
+    """Emit periodic lease heartbeat to indicate the process is alive."""
+    emit_event("lease_heartbeat", leaseId=lease_id)
+

--- a/ghosthands/worker/executor.py
+++ b/ghosthands/worker/executor.py
@@ -493,6 +493,7 @@ Other rules:
         job_id=job_id,
         max_budget=settings.max_budget_per_job,
         on_status_update=_on_status,
+        keep_alive=False,  # EC2 worker path — no human reviewer
     )
 
     log.info(
@@ -502,6 +503,27 @@ Other rules:
         cost=result.get("cost_usd"),
         blocker=result.get("blocker"),
     )
+
+    # ── HITL: pause on blocker ───────────────────────────────────
+    if result.get("blocker"):
+        log.info("executor.hitl_pause", blocker=result["blocker"])
+        await hitl.pause_job(
+            job_id=job_id,
+            reason=result["blocker"],
+            interaction_type="blocker",
+            valet_task_id=valet_task_id,
+        )
+        signal = await hitl.wait_for_resume(job_id)
+        if signal and signal.get("action") == "cancel":
+            return {
+                "success": False,
+                "summary": "Cancelled by user",
+                "steps_taken": result.get("steps", 0),
+                "cost_usd": result.get("cost_usd", 0.0),
+                "blocker": result.get("blocker"),
+                "error_code": "user_cancelled",
+            }
+        # On resume, result is already captured -- continue to completion
 
     # ── Map to executor result format ────────────────────────────
     return {

--- a/tests/ci/test_agent_factory_lifecycle.py
+++ b/tests/ci/test_agent_factory_lifecycle.py
@@ -2,11 +2,9 @@
 
 Tests cover:
 - create_job_agent() — verifies Agent is created with correct parameters
-- run_job_agent() — verifies the finally-block always kills the browser
-  CRITICAL: Documents that run_job_agent UNCONDITIONALLY calls browser_session.kill(),
-  ignoring keep_alive=True set during creation. This is intentional for the worker
-  path (no human reviewer), but callers wanting HITL/review must use
-  create_job_agent() directly.
+- run_job_agent() — verifies keep_alive controls browser cleanup:
+  * keep_alive=False → browser_session.kill()  (EC2 worker path)
+  * keep_alive=True/None → event_bus.stop()     (Desktop/HITL path)
 """
 
 from __future__ import annotations
@@ -103,6 +101,41 @@ def sample_profile():
         "education": [],
         "skills": [],
     }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_agent(*, run_side_effect=None, is_done=True, n_steps=3):
+    """Create a mock Agent with explicit event_bus mock for keep_alive tests."""
+    mock_agent = AsyncMock()
+
+    # Browser session with both kill() and event_bus.stop()
+    mock_event_bus = AsyncMock()
+    mock_event_bus.stop = AsyncMock()
+
+    mock_browser_session = AsyncMock()
+    mock_browser_session.kill = AsyncMock()
+    mock_browser_session.event_bus = mock_event_bus
+
+    mock_agent.browser_session = mock_browser_session
+
+    # Agent run result
+    mock_history = MagicMock()
+    mock_history.is_done.return_value = is_done
+    mock_history.history = []
+
+    if run_side_effect:
+        mock_agent.run = AsyncMock(side_effect=run_side_effect)
+    else:
+        mock_agent.run = AsyncMock(return_value=mock_history)
+
+    mock_agent.state = MagicMock()
+    mock_agent.state.n_steps = n_steps
+
+    return mock_agent
 
 
 # ---------------------------------------------------------------------------
@@ -317,103 +350,114 @@ async def test_create_job_agent_extends_system_message(mock_prompt, mock_get_mod
 
 
 # ---------------------------------------------------------------------------
-# run_job_agent tests
+# run_job_agent tests — S3: keep_alive controls browser cleanup
 # ---------------------------------------------------------------------------
 
 
 @patch("ghosthands.agent.factory.create_job_agent")
-async def test_run_job_agent_always_kills_browser(mock_create, sample_profile):
-    """BASELINE: run_job_agent UNCONDITIONALLY kills browser in finally block.
-    This is the documented behavior: the worker convenience wrapper always
-    kills the browser because there is no human reviewer in the worker path.
-    Callers wanting keep_alive behavior should use create_job_agent() directly.
-    NOTE: The browser profile has keep_alive=True but run_job_agent ignores it."""
-    # Set up mock agent
-    mock_agent = AsyncMock()
-    mock_browser_session = AsyncMock()
-    mock_browser_session.kill = AsyncMock()
-
-    # Mock browser_profile with keep_alive=True (as factory sets it)
-    mock_browser_profile = MagicMock()
-    mock_browser_profile.keep_alive = True
-    mock_browser_session.browser_profile = mock_browser_profile
-
-    mock_agent.browser_session = mock_browser_session
-
-    # Mock agent.run() to return a history with is_done()=True
-    mock_history = MagicMock()
-    mock_history.is_done.return_value = True
-    mock_history.history = []
-    mock_agent.run = AsyncMock(return_value=mock_history)
-    mock_agent.state = MagicMock()
-    mock_agent.state.n_steps = 3
-
+async def test_run_job_agent_keep_alive_false_kills_browser(mock_create, sample_profile):
+    """S3: keep_alive=False calls browser_session.kill(), NOT event_bus.stop()."""
+    mock_agent = _make_mock_agent()
     mock_create.return_value = mock_agent
 
     await run_job_agent(
         task="Apply to https://example.com",
         resume_profile=sample_profile,
+        keep_alive=False,
     )
 
-    # BASELINE: kill() is ALWAYS called, even though keep_alive=True
-    mock_browser_session.kill.assert_called_once()
+    mock_agent.browser_session.kill.assert_called_once()
+    mock_agent.browser_session.event_bus.stop.assert_not_called()
 
 
 @patch("ghosthands.agent.factory.create_job_agent")
-async def test_run_job_agent_kills_browser_on_exception(mock_create, sample_profile):
-    """BASELINE: Browser is killed even when agent.run() raises an exception."""
-    mock_agent = AsyncMock()
-    mock_browser_session = AsyncMock()
-    mock_browser_session.kill = AsyncMock()
-    mock_agent.browser_session = mock_browser_session
+async def test_run_job_agent_keep_alive_true_preserves_browser(mock_create, sample_profile):
+    """S3: keep_alive=True calls event_bus.stop(clear=False, timeout=1.0), NOT kill()."""
+    mock_agent = _make_mock_agent()
+    mock_create.return_value = mock_agent
 
-    # Make agent.run() raise an error
-    mock_agent.run = AsyncMock(side_effect=RuntimeError("LLM failed"))
+    await run_job_agent(
+        task="Apply to https://example.com",
+        resume_profile=sample_profile,
+        keep_alive=True,
+    )
 
+    mock_agent.browser_session.kill.assert_not_called()
+    mock_agent.browser_session.event_bus.stop.assert_called_once_with(clear=False, timeout=1.0)
+
+
+@patch("ghosthands.agent.factory.create_job_agent")
+async def test_run_job_agent_keep_alive_none_preserves_browser(mock_create, sample_profile):
+    """S3: keep_alive=None (default) treats as True — event_bus.stop(), NOT kill()."""
+    mock_agent = _make_mock_agent()
+    mock_create.return_value = mock_agent
+
+    await run_job_agent(
+        task="Apply to https://example.com",
+        resume_profile=sample_profile,
+        # keep_alive defaults to None
+    )
+
+    mock_agent.browser_session.kill.assert_not_called()
+    mock_agent.browser_session.event_bus.stop.assert_called_once_with(clear=False, timeout=1.0)
+
+
+@patch("ghosthands.agent.factory.create_job_agent")
+async def test_run_job_agent_keep_alive_false_kills_on_exception(mock_create, sample_profile):
+    """S3: keep_alive=False still calls kill() when agent.run() raises."""
+    mock_agent = _make_mock_agent(run_side_effect=RuntimeError("LLM failed"))
     mock_create.return_value = mock_agent
 
     with pytest.raises(RuntimeError, match="LLM failed"):
         await run_job_agent(
             task="Apply to https://example.com",
             resume_profile=sample_profile,
+            keep_alive=False,
         )
 
-    # BASELINE: kill() called in finally even on exception
-    mock_browser_session.kill.assert_called_once()
+    mock_agent.browser_session.kill.assert_called_once()
+    mock_agent.browser_session.event_bus.stop.assert_not_called()
 
 
 @patch("ghosthands.agent.factory.create_job_agent")
-async def test_run_job_agent_handles_kill_exception_gracefully(mock_create, sample_profile):
-    """BASELINE: If browser_session.kill() itself raises, the exception is swallowed."""
-    mock_agent = AsyncMock()
-    mock_browser_session = AsyncMock()
-    mock_browser_session.kill = AsyncMock(side_effect=Exception("Browser already closed"))
-    mock_agent.browser_session = mock_browser_session
-
-    # Normal run
-    mock_history = MagicMock()
-    mock_history.is_done.return_value = True
-    mock_history.history = []
-    mock_agent.run = AsyncMock(return_value=mock_history)
-    mock_agent.state = MagicMock()
-    mock_agent.state.n_steps = 1
-
+async def test_run_job_agent_keep_alive_true_preserves_on_exception(mock_create, sample_profile):
+    """S3: keep_alive=True calls event_bus.stop() even when agent.run() raises."""
+    mock_agent = _make_mock_agent(run_side_effect=RuntimeError("LLM failed"))
     mock_create.return_value = mock_agent
 
-    # Should NOT raise even though kill() failed
+    with pytest.raises(RuntimeError, match="LLM failed"):
+        await run_job_agent(
+            task="Apply to https://example.com",
+            resume_profile=sample_profile,
+            keep_alive=True,
+        )
+
+    mock_agent.browser_session.kill.assert_not_called()
+    mock_agent.browser_session.event_bus.stop.assert_called_once_with(clear=False, timeout=1.0)
+
+
+@patch("ghosthands.agent.factory.create_job_agent")
+async def test_run_job_agent_handles_event_bus_stop_exception_gracefully(mock_create, sample_profile):
+    """S3: If event_bus.stop() raises, the exception is swallowed."""
+    mock_agent = _make_mock_agent()
+    mock_agent.browser_session.event_bus.stop = AsyncMock(side_effect=Exception("Bus error"))
+    mock_create.return_value = mock_agent
+
+    # Should NOT raise even though event_bus.stop() failed
     result = await run_job_agent(
         task="Apply to https://example.com",
         resume_profile=sample_profile,
+        keep_alive=True,
     )
 
     assert isinstance(result, dict)
 
 
 @patch("ghosthands.agent.factory.create_job_agent")
-async def test_run_job_agent_skips_kill_when_browser_session_is_none(mock_create, sample_profile):
-    """BASELINE: If browser_session is None, kill() is not called (no crash)."""
+async def test_run_job_agent_skips_cleanup_when_browser_session_is_none(mock_create, sample_profile):
+    """S3: If browser_session is None, no cleanup is attempted (no crash)."""
     mock_agent = AsyncMock()
-    mock_agent.browser_session = None  # No browser session
+    mock_agent.browser_session = None
 
     mock_history = MagicMock()
     mock_history.is_done.return_value = False
@@ -424,7 +468,6 @@ async def test_run_job_agent_skips_kill_when_browser_session_is_none(mock_create
 
     mock_create.return_value = mock_agent
 
-    # Should not crash
     result = await run_job_agent(
         task="Apply to https://example.com",
         resume_profile=sample_profile,
@@ -438,9 +481,8 @@ async def test_run_job_agent_skips_kill_when_browser_session_is_none(mock_create
 async def test_run_job_agent_returns_success_result(mock_create, sample_profile):
     """BASELINE: run_job_agent returns a result dict with expected keys on success."""
     mock_agent = AsyncMock()
-    mock_agent.browser_session = None  # skip kill for simplicity
+    mock_agent.browser_session = None  # skip cleanup for simplicity
 
-    # Build a mock history entry with is_done=True and success result
     mock_result = MagicMock()
     mock_result.is_done = True
     mock_result.success = True
@@ -452,8 +494,6 @@ async def test_run_job_agent_returns_success_result(mock_create, sample_profile)
     mock_history = MagicMock()
     mock_history.is_done.return_value = True
     mock_history.history = [mock_last_entry]
-    mock_history.usage = MagicMock()
-    mock_history.usage.total_cost = 0.05
 
     mock_agent.run = AsyncMock(return_value=mock_history)
     mock_agent.state = MagicMock()
@@ -466,7 +506,6 @@ async def test_run_job_agent_returns_success_result(mock_create, sample_profile)
         resume_profile=sample_profile,
     )
 
-    # BASELINE: result dict shape
     assert result["success"] is True
     assert result["steps"] == 10
     assert "cost_usd" in result
@@ -503,7 +542,6 @@ async def test_run_job_agent_detects_blocker_in_result(mock_create, sample_profi
         resume_profile=sample_profile,
     )
 
-    # BASELINE: blocker detection uses case-insensitive 'blocker:' check
     assert result["blocker"] is not None
     assert "CAPTCHA" in result["blocker"]
 
@@ -515,7 +553,7 @@ async def test_run_job_agent_not_done_returns_failure(mock_create, sample_profil
     mock_agent.browser_session = None
 
     mock_history = MagicMock()
-    mock_history.is_done.return_value = False  # Not done
+    mock_history.is_done.return_value = False
     mock_history.history = []
 
     mock_agent.run = AsyncMock(return_value=mock_history)
@@ -555,10 +593,26 @@ async def test_run_job_agent_passes_hooks_to_agent_run(mock_create, sample_profi
         job_id="test-job-123",
     )
 
-    # BASELINE: agent.run() is called with on_step_start and on_step_end kwargs
     mock_agent.run.assert_called_once()
     call_kwargs = mock_agent.run.call_args.kwargs
     assert "on_step_start" in call_kwargs
     assert "on_step_end" in call_kwargs
     assert callable(call_kwargs["on_step_start"])
     assert callable(call_kwargs["on_step_end"])
+
+
+@patch("ghosthands.agent.factory.create_job_agent")
+async def test_run_job_agent_handles_kill_exception_gracefully(mock_create, sample_profile):
+    """BASELINE: If browser_session.kill() itself raises, the exception is swallowed."""
+    mock_agent = _make_mock_agent()
+    mock_agent.browser_session.kill = AsyncMock(side_effect=Exception("Browser already closed"))
+    mock_create.return_value = mock_agent
+
+    # Should NOT raise even though kill() failed
+    result = await run_job_agent(
+        task="Apply to https://example.com",
+        resume_profile=sample_profile,
+        keep_alive=False,
+    )
+
+    assert isinstance(result, dict)

--- a/tests/ci/test_jsonl_output.py
+++ b/tests/ci/test_jsonl_output.py
@@ -55,8 +55,8 @@ class TestEmitEvent:
         from ghosthands.output.jsonl import emit_event
 
         obj = _capture_emit(emit_event, "status", message="hello")
-        # BASELINE: "type" key — will change to "event" in S2
-        assert "type" in obj
+        # CHANGED in S2: "event" key (was "type")
+        assert "event" in obj
         assert obj["event"] == "status"
 
     def test_includes_timestamp(self):

--- a/tests/ci/test_jsonl_output.py
+++ b/tests/ci/test_jsonl_output.py
@@ -46,18 +46,18 @@ def _capture_emit(fn, *args, **kwargs) -> dict:
 class TestEmitEvent:
     """Tests for the core emit_event() function."""
 
-    def test_output_uses_type_key(self):
-        """emit_event uses 'type' key for the event type.
+    def test_output_uses_event_key(self):
+        """emit_event uses 'event' key for the event type.
 
-        # BASELINE: Current code uses "type" as the key name.
-        # NOTE: Stream S2 will intentionally rename this to "event".
+        # CHANGED in S2: Key renamed from "type" to "event" to match
+        # the Desktop app's HandXEvent interface.
         """
         from ghosthands.output.jsonl import emit_event
 
         obj = _capture_emit(emit_event, "status", message="hello")
         # BASELINE: "type" key — will change to "event" in S2
         assert "type" in obj
-        assert obj["type"] == "status"
+        assert obj["event"] == "status"
 
     def test_includes_timestamp(self):
         """Every event includes an integer millisecond timestamp."""
@@ -146,8 +146,8 @@ class TestEmitStatus:
         from ghosthands.output.jsonl import emit_status
 
         obj = _capture_emit(emit_status, "Processing step 1")
-        # BASELINE: uses "type" key
-        assert obj["type"] == "status"
+        # CHANGED in S2: uses "event" key (was "type")
+        assert obj["event"] == "status"
         assert obj["message"] == "Processing step 1"
         assert "timestamp" in obj
 
@@ -204,7 +204,7 @@ class TestEmitDone:
             job_id="job-1",
             lease_id="lease-1",
         )
-        assert obj["type"] == "done"
+        assert obj["event"] == "done"
         assert obj["success"] is True
         assert obj["message"] == "Completed"
         assert obj["fields_filled"] == 5
@@ -217,7 +217,7 @@ class TestEmitDone:
         from ghosthands.output.jsonl import emit_done
 
         obj = _capture_emit(emit_done, success=False, message="Failed to fill")
-        assert obj["type"] == "done"
+        assert obj["event"] == "done"
         assert obj["success"] is False
         assert obj["message"] == "Failed to fill"
 
@@ -262,7 +262,7 @@ class TestEmitFieldFilled:
         from ghosthands.output.jsonl import emit_field_filled
 
         obj = _capture_emit(emit_field_filled, "first_name", "Jane")
-        assert obj["type"] == "field_filled"
+        assert obj["event"] == "field_filled"
         assert obj["field"] == "first_name"
         assert obj["value"] == "Jane"
         assert "timestamp" in obj
@@ -297,9 +297,10 @@ class TestEmitFieldFailed:
         from ghosthands.output.jsonl import emit_field_failed
 
         obj = _capture_emit(emit_field_failed, "phone", "Element not found")
-        assert obj["type"] == "field_failed"
+        assert obj["event"] == "field_failed"
         assert obj["field"] == "phone"
-        assert obj["error"] == "Element not found"
+        assert obj["reason"] == "Element not found"
+        assert "error" not in obj
         assert "timestamp" in obj
 
 
@@ -316,7 +317,7 @@ class TestEmitProgress:
         from ghosthands.output.jsonl import emit_progress
 
         obj = _capture_emit(emit_progress, 5, 10)
-        assert obj["type"] == "progress"
+        assert obj["event"] == "progress"
         assert obj["filled"] == 5
         assert obj["total"] == 10
         assert "timestamp" in obj
@@ -349,7 +350,7 @@ class TestEmitError:
         from ghosthands.output.jsonl import emit_error
 
         obj = _capture_emit(emit_error, "Something went wrong")
-        assert obj["type"] == "error"
+        assert obj["event"] == "error"
         assert obj["message"] == "Something went wrong"
         assert "timestamp" in obj
 
@@ -395,7 +396,7 @@ class TestEmitCost:
         from ghosthands.output.jsonl import emit_cost
 
         obj = _capture_emit(emit_cost, 0.123456)
-        assert obj["type"] == "cost"
+        assert obj["event"] == "cost"
         assert obj["total_usd"] == 0.123456
         assert "timestamp" in obj
 
@@ -442,3 +443,157 @@ class TestGetOutput:
         out = _get_output()
         import sys
         assert out is sys.stdout
+
+
+# ---------------------------------------------------------------------------
+# Progress field additions (ADDED in S2)
+# ---------------------------------------------------------------------------
+
+
+class TestEmitProgressS2:
+    """Tests for the S2 additions to emit_progress()."""
+
+    def test_progress_includes_step_and_maxsteps(self):
+        """emit_progress also emits step (= filled) and maxSteps (= total)."""
+        from ghosthands.output.jsonl import emit_progress
+
+        obj = _capture_emit(emit_progress, 5, 10)
+        assert obj["step"] == 5
+        assert obj["maxSteps"] == 10
+
+    def test_progress_description_omitted_when_empty(self):
+        """description is omitted when not provided (empty string -> None)."""
+        from ghosthands.output.jsonl import emit_progress
+
+        obj = _capture_emit(emit_progress, 3, 8)
+        assert "description" not in obj
+
+    def test_progress_description_included_when_provided(self):
+        """description is included when a non-empty string is provided."""
+        from ghosthands.output.jsonl import emit_progress
+
+        obj = _capture_emit(emit_progress, 3, 8, description="Filling page 2")
+        assert obj["description"] == "Filling page 2"
+
+
+# ---------------------------------------------------------------------------
+# Lease protocol events (ADDED in S2)
+# ---------------------------------------------------------------------------
+
+
+class TestEmitHandshake:
+    """Tests for the emit_handshake() lease protocol event."""
+
+    def test_handshake_default_version(self):
+        """emit_handshake emits a handshake event with protocol_version=2."""
+        from ghosthands.output.jsonl import emit_handshake
+
+        obj = _capture_emit(emit_handshake)
+        assert obj["event"] == "handshake"
+        assert obj["protocol_version"] == 2
+        assert "timestamp" in obj
+
+    def test_handshake_custom_version(self):
+        """emit_handshake accepts a custom protocol version."""
+        from ghosthands.output.jsonl import emit_handshake
+
+        obj = _capture_emit(emit_handshake, protocol_version=3)
+        assert obj["protocol_version"] == 3
+
+
+class TestEmitBrowserReady:
+    """Tests for the emit_browser_ready() lease protocol event."""
+
+    def test_browser_ready(self):
+        """emit_browser_ready emits a browser_ready event with cdpUrl."""
+        from ghosthands.output.jsonl import emit_browser_ready
+
+        obj = _capture_emit(emit_browser_ready, "ws://127.0.0.1:9222/devtools/browser/abc")
+        assert obj["event"] == "browser_ready"
+        assert obj["cdpUrl"] == "ws://127.0.0.1:9222/devtools/browser/abc"
+        assert "timestamp" in obj
+
+    def test_browser_ready_empty_url(self):
+        """emit_browser_ready with empty CDP URL still emits the event."""
+        from ghosthands.output.jsonl import emit_browser_ready
+
+        obj = _capture_emit(emit_browser_ready, "")
+        assert obj["event"] == "browser_ready"
+        assert obj["cdpUrl"] == ""
+
+
+class TestEmitLeaseAcquired:
+    """Tests for the emit_lease_acquired() lease protocol event."""
+
+    def test_lease_acquired_basic(self):
+        """emit_lease_acquired emits a lease_acquired event with leaseId."""
+        from ghosthands.output.jsonl import emit_lease_acquired
+
+        obj = _capture_emit(emit_lease_acquired, "lease-abc-123")
+        assert obj["event"] == "lease_acquired"
+        assert obj["leaseId"] == "lease-abc-123"
+        assert "timestamp" in obj
+
+    def test_lease_acquired_with_job_id(self):
+        """emit_lease_acquired includes jobId when provided."""
+        from ghosthands.output.jsonl import emit_lease_acquired
+
+        obj = _capture_emit(emit_lease_acquired, "lease-1", job_id="job-42")
+        assert obj["leaseId"] == "lease-1"
+        assert obj["jobId"] == "job-42"
+
+    def test_lease_acquired_empty_job_id_omitted(self):
+        """Empty string job_id is converted to None and omitted."""
+        from ghosthands.output.jsonl import emit_lease_acquired
+
+        obj = _capture_emit(emit_lease_acquired, "lease-1", job_id="")
+        assert "jobId" not in obj
+
+    def test_lease_acquired_default_job_id_omitted(self):
+        """Default job_id (empty string) is omitted."""
+        from ghosthands.output.jsonl import emit_lease_acquired
+
+        obj = _capture_emit(emit_lease_acquired, "lease-1")
+        assert "jobId" not in obj
+
+
+class TestEmitLeaseReleased:
+    """Tests for the emit_lease_released() lease protocol event."""
+
+    def test_lease_released_default_reason(self):
+        """emit_lease_released emits a lease_released event with default reason."""
+        from ghosthands.output.jsonl import emit_lease_released
+
+        obj = _capture_emit(emit_lease_released, "lease-abc-123")
+        assert obj["event"] == "lease_released"
+        assert obj["leaseId"] == "lease-abc-123"
+        assert obj["reason"] == "completed"
+        assert "timestamp" in obj
+
+    def test_lease_released_custom_reason(self):
+        """emit_lease_released accepts a custom reason."""
+        from ghosthands.output.jsonl import emit_lease_released
+
+        obj = _capture_emit(emit_lease_released, "lease-1", reason="error")
+        assert obj["reason"] == "error"
+
+    def test_lease_released_failed_reason(self):
+        """emit_lease_released with reason='failed'."""
+        from ghosthands.output.jsonl import emit_lease_released
+
+        obj = _capture_emit(emit_lease_released, "lease-1", reason="failed")
+        assert obj["reason"] == "failed"
+
+
+class TestEmitLeaseHeartbeat:
+    """Tests for the emit_lease_heartbeat() lease protocol event."""
+
+    def test_lease_heartbeat(self):
+        """emit_lease_heartbeat emits a lease_heartbeat event with leaseId."""
+        from ghosthands.output.jsonl import emit_lease_heartbeat
+
+        obj = _capture_emit(emit_lease_heartbeat, "lease-abc-123")
+        assert obj["event"] == "lease_heartbeat"
+        assert obj["leaseId"] == "lease-abc-123"
+        assert "timestamp" in obj
+


### PR DESCRIPTION
## Summary
- S0: 154 baseline tests for GhostHands code
- S2: Fix JSONL type→event key mismatch, add lease protocol events
- S3: Fix keep_alive unconditional kill, wire HITL into executor

## Test plan
- [ ] 173 tests pass
- [ ] JSONL uses event key
- [ ] keep_alive=True preserves browser
- [ ] HITL wired into executor

Generated with Claude Code