### PR TITLE
feat(security): wire domain lockdown into CLI path (S4)

### DIFF
--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -91,6 +91,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--proxy-url", default=None, help="VALET LLM proxy URL")
     parser.add_argument("--runtime-grant", default=None, help="VALET runtime grant token")
 
+    # Security
+    parser.add_argument(
+        "--allowed-domains",
+        type=str,
+        default=None,
+        help="Comma-separated list of additional allowed domains",
+    )
+
     # Playwright
     parser.add_argument("--browsers-path", default=None, help="Path to Playwright browser binaries")
 
@@ -209,6 +217,20 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
     except ImportError:
         pass
 
+    # -- Domain lockdown ----------------------------------------------------
+    from ghosthands.security.domain_lockdown import create_lockdown_for_platform
+
+    additional_domains: list[str] | None = None
+    if args.allowed_domains:
+        additional_domains = [d.strip() for d in args.allowed_domains.split(",") if d.strip()]
+
+    lockdown = create_lockdown_for_platform(
+        job_url=args.job_url,
+        platform=platform,
+        additional_domains=additional_domains,
+    )
+    allowed_domains = lockdown.get_allowed_domains()
+
     # -- System prompt ------------------------------------------------------
     system_ext = ""
     try:
@@ -231,6 +253,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
         demo_mode=False,
         interaction_highlight_color="rgb(37, 99, 235)",
         wait_between_actions=settings.wait_between_actions,
+        allowed_domains=allowed_domains,
     )
     browser = BrowserSession(browser_profile=browser_profile)
 
@@ -408,6 +431,20 @@ async def run_agent_human(args: argparse.Namespace) -> None:
     except ImportError:
         pass
 
+    # -- Domain lockdown ----------------------------------------------------
+    from ghosthands.security.domain_lockdown import create_lockdown_for_platform
+
+    additional_domains: list[str] | None = None
+    if args.allowed_domains:
+        additional_domains = [d.strip() for d in args.allowed_domains.split(",") if d.strip()]
+
+    lockdown = create_lockdown_for_platform(
+        job_url=args.job_url,
+        platform=platform,
+        additional_domains=additional_domains,
+    )
+    allowed_domains = lockdown.get_allowed_domains()
+
     # -- System prompt ------------------------------------------------------
     system_ext = ""
     try:
@@ -430,6 +467,7 @@ async def run_agent_human(args: argparse.Namespace) -> None:
         demo_mode=False,
         interaction_highlight_color="rgb(37, 99, 235)",
         wait_between_actions=settings.wait_between_actions,
+        allowed_domains=allowed_domains,
     )
     browser = BrowserSession(browser_profile=browser_profile)
 

--- a/tests/ci/test_cli_args.py
+++ b/tests/ci/test_cli_args.py
@@ -1,8 +1,7 @@
-"""Baseline regression tests for ghosthands.cli argument parsing.
+"""Regression tests for ghosthands.cli argument parsing.
 
-These tests capture the CURRENT behavior of the CLI argument parser so that
-future changes (e.g., S4 adding --allowed-domains) are validated against a
-known-good baseline.
+These tests capture the behavior of the CLI argument parser. S4 added
+--allowed-domains for domain lockdown wiring.
 
 Because ghosthands.cli imports heavy dependencies at module level
 (ghosthands.agent.hooks -> browser-use -> cdp_use), we mock those modules
@@ -430,32 +429,57 @@ class TestApplySubcommand:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# --allowed-domains (S4: domain lockdown wiring)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedDomains:
+    """Tests for --allowed-domains argument (added in S4)."""
+
+    def test_allowed_domains_default_none(self):
+        """--allowed-domains defaults to None when not provided."""
+        args = _parse(["--job-url", "https://example.com"])
+        assert args.allowed_domains is None
+
+    def test_allowed_domains_single(self):
+        """--allowed-domains accepts a single domain."""
+        args = _parse([
+            "--job-url", "https://example.com",
+            "--allowed-domains", "greenhouse.io",
+        ])
+        assert args.allowed_domains == "greenhouse.io"
+
+    def test_allowed_domains_comma_separated(self):
+        """--allowed-domains accepts a comma-separated list."""
+        args = _parse([
+            "--job-url", "https://example.com",
+            "--allowed-domains", "greenhouse.io,lever.co,sso.company.com",
+        ])
+        assert args.allowed_domains == "greenhouse.io,lever.co,sso.company.com"
+
+    def test_allowed_domains_is_string(self):
+        """--allowed-domains is stored as a raw string (parsed later in CLI flow)."""
+        args = _parse([
+            "--job-url", "https://example.com",
+            "--allowed-domains", "example.com",
+        ])
+        assert isinstance(args.allowed_domains, str)
+
+
+# ---------------------------------------------------------------------------
+# Remaining gaps for future streams
+# ---------------------------------------------------------------------------
+
+
 class TestFutureGaps:
-    """Document arguments that do NOT currently exist.
-
-    These tests serve as a contract: if a future stream adds these args,
-    the corresponding test should be updated to assert the new behavior.
-    """
-
-    def test_allowed_domains_does_not_exist(self):
-        """--allowed-domains is NOT a current CLI argument.
-
-        # BASELINE: S4 will add --allowed-domains for domain allowlisting.
-        # When S4 lands, this test should be replaced with positive tests.
-        """
-        with pytest.raises(SystemExit):
-            _parse([
-                "--job-url", "https://example.com",
-                "--allowed-domains", "greenhouse.io,lever.co",
-            ])
+    """Document arguments that do NOT currently exist."""
 
     def test_keep_alive_does_not_exist_as_cli_flag(self):
         """--keep-alive is NOT a current CLI argument.
 
         Note: keep_alive is hardcoded to True in the BrowserProfile construction
         inside run_agent_jsonl/run_agent_human, but is not exposed as a CLI flag.
-
-        # BASELINE: keep_alive is always True, not configurable via CLI.
         """
         with pytest.raises(SystemExit):
             _parse([

--- a/tests/ci/test_domain_lockdown_integration.py
+++ b/tests/ci/test_domain_lockdown_integration.py
@@ -1,12 +1,12 @@
-"""Baseline regression tests for ghosthands.security.domain_lockdown.
+"""Regression tests for ghosthands.security.domain_lockdown.
 
 Tests cover:
 - DomainLockdown.is_allowed() — URL allowlist enforcement
 - Platform-specific domain lists (Workday, Greenhouse, Lever, etc.)
 - check_and_record() — stats tracking and cross-origin resource handling
 - Convenience functions: is_url_allowed(), create_lockdown_for_platform()
-- CRITICAL: Documents that cli.py does NOT use DomainLockdown — BrowserProfile
-  is created without allowed_domains, leaving the security gap that S4 will fix.
+- S4 FIXED: Verifies cli.py NOW wires DomainLockdown — BrowserProfile
+  is created with allowed_domains in both JSONL and human paths.
 """
 
 import inspect
@@ -431,33 +431,26 @@ def test_create_lockdown_for_platform():
 
 
 # ---------------------------------------------------------------------------
-# CLI path does NOT wire domain lockdown (security gap S4 will fix)
+# CLI path DOES wire domain lockdown (S4 fixed the security gap)
 # ---------------------------------------------------------------------------
 
 
-def test_cli_path_does_not_use_domain_lockdown():
-    """BASELINE: CLI creates BrowserProfile WITHOUT allowed_domains.
-    NOTE: Stream S4 will fix this security gap by wiring DomainLockdown
-    into the CLI path.
+def test_cli_path_uses_domain_lockdown():
+    """S4 FIXED: CLI creates BrowserProfile WITH allowed_domains.
 
-    The CLI's run_agent_jsonl and run_agent_human both construct BrowserProfile
-    without passing allowed_domains, leaving the browser unrestricted.
-    In contrast, create_job_agent in factory.py DOES pass allowed_domains."""
+    Both run_agent_jsonl and run_agent_human construct BrowserProfile with
+    allowed_domains via create_lockdown_for_platform(), matching the security
+    boundary that already existed in factory.py's create_job_agent."""
     import ast
 
     from ghosthands import cli
 
-    # Read the source of cli.py and check that BrowserProfile is constructed
-    # without allowed_domains in both run_agent_jsonl and run_agent_human
     source = inspect.getsource(cli)
-
-    # Parse into AST
     tree = ast.parse(source)
 
     browser_profile_calls = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Call):
-            # Check if this is a BrowserProfile(...) call
             func = node.func
             func_name = None
             if isinstance(func, ast.Name):
@@ -466,33 +459,33 @@ def test_cli_path_does_not_use_domain_lockdown():
                 func_name = func.attr
 
             if func_name == "BrowserProfile":
-                # Collect keyword argument names
                 kwarg_names = [kw.arg for kw in node.keywords if kw.arg is not None]
                 browser_profile_calls.append(kwarg_names)
 
-    # BASELINE: There should be BrowserProfile calls in cli.py
+    # There should be BrowserProfile calls in cli.py (jsonl + human)
     assert len(browser_profile_calls) >= 2, (
         f"Expected at least 2 BrowserProfile calls in cli.py (jsonl + human), "
         f"found {len(browser_profile_calls)}"
     )
 
-    # BASELINE: NONE of the BrowserProfile calls include 'allowed_domains'
+    # S4 FIXED: ALL BrowserProfile calls in cli.py now include 'allowed_domains'
     for i, kwargs in enumerate(browser_profile_calls):
-        assert "allowed_domains" not in kwargs, (
-            f"BrowserProfile call #{i + 1} in cli.py has 'allowed_domains' — "
-            f"this test documents the ABSENCE of domain lockdown in CLI. "
-            f"If S4 has been implemented, update this test."
+        assert "allowed_domains" in kwargs, (
+            f"BrowserProfile call #{i + 1} in cli.py is missing 'allowed_domains' — "
+            f"S4 domain lockdown wiring is incomplete"
         )
 
 
 def test_factory_path_does_use_domain_lockdown():
     """BASELINE: create_job_agent in factory.py DOES pass allowed_domains to BrowserProfile.
-    This confirms the security boundary exists in the worker path but not CLI."""
+    This confirms the security boundary exists in the worker path as well as CLI."""
     import ast
+    from pathlib import Path
 
-    from ghosthands.agent import factory
-
-    source = inspect.getsource(factory)
+    # Read factory.py by file path instead of inspect.getsource() to avoid
+    # failures when another test has stubbed ghosthands.agent.factory in sys.modules.
+    factory_path = Path(__file__).resolve().parent.parent.parent / "ghosthands" / "agent" / "factory.py"
+    source = factory_path.read_text()
     tree = ast.parse(source)
 
     browser_profile_calls = []


### PR DESCRIPTION
Wire DomainLockdown into CLI path. Add --allowed-domains flag. Both run_agent_jsonl() and run_agent_human() protected. 157 tests.