### PR TITLE
feat(browser): BrowserProvider abstraction for engine swapping (S5)

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -577,6 +577,10 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	# custom options we provide that aren't native playwright kwargs
 	disable_security: bool = Field(default=False, description='Disable browser security features.')
+	engine: Literal['chromium', 'firefox', 'auto'] = Field(
+		default='chromium',
+		description="Browser engine to use. 'chromium' (default), 'firefox' for Camoufox, 'auto' for route-based selection.",
+	)
 	deterministic_rendering: bool = Field(default=False, description='Enable deterministic rendering flags.')
 	allowed_domains: list[str] | set[str] | None = Field(
 		default=None,

--- a/browser_use/browser/providers/__init__.py
+++ b/browser_use/browser/providers/__init__.py
@@ -1,0 +1,13 @@
+"""Browser engine provider abstraction.
+
+Exports:
+	BrowserProvider: Abstract base class for browser engines.
+	ChromiumProvider: Chromium/Chrome engine provider.
+	ProviderRegistry: Engine name -> provider class lookup.
+"""
+
+from browser_use.browser.providers.base import BrowserProvider
+from browser_use.browser.providers.chromium import ChromiumProvider
+from browser_use.browser.providers.registry import ProviderRegistry
+
+__all__ = ['BrowserProvider', 'ChromiumProvider', 'ProviderRegistry']

--- a/browser_use/browser/providers/base.py
+++ b/browser_use/browser/providers/base.py
@@ -1,0 +1,59 @@
+"""Abstract base class for browser engine providers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from browser_use.browser.profile import BrowserProfile
+
+
+class BrowserProvider(ABC):
+	"""Abstract browser engine provider.
+
+	Decouples the agent from the specific browser engine, enabling
+	engine swapping (e.g., Chromium -> Camoufox/Firefox) without
+	changing agent code.
+	"""
+
+	@abstractmethod
+	async def launch(self, profile: BrowserProfile) -> tuple[str, int | None]:
+		"""Launch browser and return (cdp_url, process_pid_or_none).
+
+		Args:
+			profile: Browser profile with launch configuration.
+
+		Returns:
+			Tuple of (cdp_url, process_pid_or_none).
+		"""
+		...
+
+	@abstractmethod
+	async def kill(self) -> None:
+		"""Kill the browser process."""
+		...
+
+	@abstractmethod
+	def get_default_args(self, profile: BrowserProfile) -> list[str]:
+		"""Get engine-specific launch arguments.
+
+		Args:
+			profile: Browser profile to derive arguments from.
+
+		Returns:
+			List of CLI arguments for the browser engine.
+		"""
+		...
+
+	@property
+	@abstractmethod
+	def engine_name(self) -> str:
+		"""Return engine identifier: 'chromium' or 'firefox'."""
+		...
+
+	@property
+	@abstractmethod
+	def supports_cdp(self) -> bool:
+		"""Whether this engine supports CDP protocol."""
+		...

--- a/browser_use/browser/providers/chromium.py
+++ b/browser_use/browser/providers/chromium.py
@@ -1,0 +1,147 @@
+"""Chromium browser engine provider.
+
+Wraps the same Chrome binary finding, argument building, and subprocess
+spawning logic used by LocalBrowserWatchdog. This is a thin abstraction
+layer -- the watchdog continues to work as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import psutil
+
+from browser_use.browser.providers.base import BrowserProvider
+from browser_use.utils import logger
+
+if TYPE_CHECKING:
+	from browser_use.browser.profile import BrowserProfile
+
+
+class ChromiumProvider(BrowserProvider):
+	"""Chromium browser engine provider.
+
+	Delegates to the same code paths used by LocalBrowserWatchdog:
+	- Chrome binary discovery via _find_installed_browser_path()
+	- Argument building via profile.get_args()
+	- Subprocess spawning via asyncio.create_subprocess_exec()
+
+	This provider does NOT replace LocalBrowserWatchdog. It is a
+	parallel abstraction that can be used when engine-swapping is
+	needed (e.g., switching between Chromium and Firefox/Camoufox).
+	"""
+
+	def __init__(self) -> None:
+		self._process: psutil.Process | None = None
+		self._temp_dirs: list[Path] = []
+
+	@property
+	def engine_name(self) -> str:
+		"""Return engine identifier."""
+		return 'chromium'
+
+	@property
+	def supports_cdp(self) -> bool:
+		"""Chromium fully supports CDP."""
+		return True
+
+	async def launch(self, profile: BrowserProfile) -> tuple[str, int | None]:
+		"""Launch Chromium browser and return (cdp_url, pid).
+
+		Uses the same logic as LocalBrowserWatchdog._launch_browser():
+		1. Build launch args from profile.get_args()
+		2. Find Chrome binary (custom path or system search)
+		3. Spawn subprocess
+		4. Wait for CDP to be ready
+
+		Args:
+			profile: Browser profile with launch configuration.
+
+		Returns:
+			Tuple of (cdp_url, process_pid_or_none).
+		"""
+		from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+		# Build args from profile (same as watchdog)
+		launch_args = profile.get_args()
+
+		# Add debugging port
+		debug_port = LocalBrowserWatchdog._find_free_port()
+		launch_args.append(f'--remote-debugging-port={debug_port}')
+
+		# Find browser executable (same priority as watchdog)
+		if profile.executable_path:
+			browser_path = profile.executable_path
+		else:
+			browser_path = LocalBrowserWatchdog._find_installed_browser_path(channel=profile.channel)
+			if not browser_path:
+				raise RuntimeError(
+					'No local Chrome/Chromium install found. '
+					'Set executable_path in BrowserProfile or install Chrome.'
+				)
+
+		logger.debug(f'[ChromiumProvider] Launching {browser_path} on CDP port {debug_port}')
+
+		# Spawn subprocess (same as watchdog)
+		subprocess = await asyncio.create_subprocess_exec(
+			browser_path,
+			*launch_args,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+
+		self._process = psutil.Process(subprocess.pid)
+
+		# Wait for CDP readiness (same as watchdog)
+		cdp_url = await LocalBrowserWatchdog._wait_for_cdp_url(debug_port)
+
+		return cdp_url, subprocess.pid
+
+	async def kill(self) -> None:
+		"""Kill the Chromium subprocess and clean up temp dirs."""
+		if self._process:
+			try:
+				self._process.terminate()
+				# Wait up to 5 seconds for graceful shutdown
+				for _ in range(50):
+					if not self._process.is_running():
+						break
+					await asyncio.sleep(0.1)
+				# Force kill if still running
+				if self._process.is_running():
+					self._process.kill()
+					await asyncio.sleep(0.1)
+			except psutil.NoSuchProcess:
+				pass
+			except Exception:
+				pass
+			finally:
+				self._process = None
+
+		# Clean up temp directories
+		for temp_dir in self._temp_dirs:
+			try:
+				if 'browseruse-tmp-' in str(temp_dir):
+					shutil.rmtree(temp_dir, ignore_errors=True)
+			except Exception:
+				pass
+		self._temp_dirs.clear()
+
+	def get_default_args(self, profile: BrowserProfile) -> list[str]:
+		"""Get Chromium launch arguments from the profile.
+
+		Delegates to profile.get_args() which handles all the
+		argument compilation logic (defaults, headless, security, etc.).
+
+		Args:
+			profile: Browser profile to derive arguments from.
+
+		Returns:
+			List of Chrome CLI arguments.
+		"""
+		return profile.get_args()

--- a/browser_use/browser/providers/registry.py
+++ b/browser_use/browser/providers/registry.py
@@ -1,0 +1,57 @@
+"""Provider registry for browser engine lookup."""
+
+from __future__ import annotations
+
+from browser_use.browser.providers.base import BrowserProvider
+from browser_use.browser.providers.chromium import ChromiumProvider
+
+
+class ProviderRegistry:
+	"""Maps engine names to provider classes.
+
+	Usage:
+		provider_cls = ProviderRegistry.get('chromium')
+		provider = provider_cls()
+		cdp_url, pid = await provider.launch(profile)
+
+	New engines are registered via:
+		ProviderRegistry.register('firefox', CamoufoxProvider)
+	"""
+
+	_providers: dict[str, type[BrowserProvider]] = {}
+
+	@classmethod
+	def register(cls, name: str, provider_class: type[BrowserProvider]) -> None:
+		"""Register a browser provider class under the given name.
+
+		Args:
+			name: Engine name (e.g., 'chromium', 'firefox').
+			provider_class: The provider class to register.
+		"""
+		cls._providers[name] = provider_class
+
+	@classmethod
+	def get(cls, name: str) -> type[BrowserProvider]:
+		"""Look up a registered provider class by engine name.
+
+		Args:
+			name: Engine name to look up.
+
+		Returns:
+			The registered provider class.
+
+		Raises:
+			NotImplementedError: If no provider is registered for the given name.
+		"""
+		if name not in cls._providers:
+			raise NotImplementedError(f"Browser provider '{name}' not registered")
+		return cls._providers[name]
+
+	@classmethod
+	def available(cls) -> list[str]:
+		"""Return list of registered engine names."""
+		return list(cls._providers.keys())
+
+
+# Auto-register the built-in chromium provider
+ProviderRegistry.register('chromium', ChromiumProvider)

--- a/tests/ci/browser/test_browser_provider.py
+++ b/tests/ci/browser/test_browser_provider.py
@@ -1,0 +1,147 @@
+"""Tests for BrowserProvider abstraction (Stream 5).
+
+Validates:
+- ProviderRegistry correctly registers and retrieves providers
+- ChromiumProvider properties and interface
+- BrowserProfile engine field accepts valid values
+- No regressions in existing BrowserProfile behavior
+"""
+
+import tempfile
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.providers import BrowserProvider, ChromiumProvider, ProviderRegistry
+
+
+class TestProviderRegistry:
+	"""Tests for ProviderRegistry lookup and registration."""
+
+	def test_get_chromium_returns_chromium_provider(self):
+		"""ProviderRegistry.get('chromium') must return ChromiumProvider."""
+		provider_cls = ProviderRegistry.get('chromium')
+		assert provider_cls is ChromiumProvider
+
+	def test_get_firefox_raises_not_implemented(self):
+		"""ProviderRegistry.get('firefox') must raise NotImplementedError (not yet registered)."""
+		with pytest.raises(NotImplementedError, match="Browser provider 'firefox' not registered"):
+			ProviderRegistry.get('firefox')
+
+	def test_get_unknown_raises_not_implemented(self):
+		"""ProviderRegistry.get with an unknown name raises NotImplementedError."""
+		with pytest.raises(NotImplementedError, match="Browser provider 'unknown_engine' not registered"):
+			ProviderRegistry.get('unknown_engine')
+
+	def test_register_and_retrieve_custom_provider(self):
+		"""Custom providers can be registered and retrieved."""
+
+		class FakeProvider(BrowserProvider):
+			@property
+			def engine_name(self) -> str:
+				return 'fake'
+
+			@property
+			def supports_cdp(self) -> bool:
+				return False
+
+			async def launch(self, profile):
+				return ('ws://fake:1234', None)
+
+			async def kill(self):
+				pass
+
+			def get_default_args(self, profile):
+				return []
+
+		ProviderRegistry.register('fake', FakeProvider)
+		try:
+			assert ProviderRegistry.get('fake') is FakeProvider
+		finally:
+			# Clean up to avoid polluting other tests
+			ProviderRegistry._providers.pop('fake', None)
+
+	def test_available_includes_chromium(self):
+		"""ProviderRegistry.available() includes 'chromium'."""
+		available = ProviderRegistry.available()
+		assert 'chromium' in available
+
+
+class TestChromiumProvider:
+	"""Tests for ChromiumProvider properties and interface."""
+
+	def test_engine_name_is_chromium(self):
+		"""ChromiumProvider.engine_name must be 'chromium'."""
+		provider = ChromiumProvider()
+		assert provider.engine_name == 'chromium'
+
+	def test_supports_cdp_is_true(self):
+		"""ChromiumProvider.supports_cdp must be True."""
+		provider = ChromiumProvider()
+		assert provider.supports_cdp is True
+
+	def test_get_default_args_returns_list(self):
+		"""ChromiumProvider.get_default_args() must return a list of strings."""
+		provider = ChromiumProvider()
+		# get_args() requires user_data_dir to be set
+		tmp_dir = tempfile.mkdtemp(prefix='browseruse-test-')
+		profile = BrowserProfile(user_data_dir=tmp_dir)
+		args = provider.get_default_args(profile)
+		assert isinstance(args, list)
+		assert len(args) > 0
+		assert all(isinstance(arg, str) for arg in args)
+
+	def test_get_default_args_contains_user_data_dir(self):
+		"""get_default_args() must include --user-data-dir (required for CDP attach)."""
+		provider = ChromiumProvider()
+		tmp_dir = tempfile.mkdtemp(prefix='browseruse-test-')
+		profile = BrowserProfile(user_data_dir=tmp_dir)
+		args = provider.get_default_args(profile)
+		assert any(arg.startswith('--user-data-dir=') for arg in args)
+
+	def test_is_subclass_of_browser_provider(self):
+		"""ChromiumProvider must be a subclass of BrowserProvider."""
+		assert issubclass(ChromiumProvider, BrowserProvider)
+
+	def test_instance_starts_with_no_process(self):
+		"""A fresh ChromiumProvider instance has no process."""
+		provider = ChromiumProvider()
+		assert provider._process is None
+		assert provider._temp_dirs == []
+
+
+class TestBrowserProfileEngine:
+	"""Tests for BrowserProfile.engine field."""
+
+	def test_default_engine_is_chromium(self):
+		"""BrowserProfile default engine is 'chromium'."""
+		profile = BrowserProfile()
+		assert profile.engine == 'chromium'
+
+	def test_engine_chromium_creates_valid_profile(self):
+		"""BrowserProfile(engine='chromium') creates a valid profile."""
+		profile = BrowserProfile(engine='chromium')
+		assert profile.engine == 'chromium'
+
+	def test_engine_auto_creates_valid_profile(self):
+		"""BrowserProfile(engine='auto') creates a valid profile."""
+		profile = BrowserProfile(engine='auto')
+		assert profile.engine == 'auto'
+
+	def test_engine_firefox_creates_valid_profile(self):
+		"""BrowserProfile(engine='firefox') creates a valid profile."""
+		profile = BrowserProfile(engine='firefox')
+		assert profile.engine == 'firefox'
+
+	def test_engine_invalid_value_raises(self):
+		"""BrowserProfile with invalid engine value raises ValidationError."""
+		with pytest.raises(Exception):
+			BrowserProfile(engine='safari')  # type: ignore[arg-type]
+
+	def test_engine_does_not_affect_get_args(self):
+		"""Setting engine does not change the output of get_args() (no behavior change yet)."""
+		tmp_dir = tempfile.mkdtemp(prefix='browseruse-test-')
+		profile_default = BrowserProfile(user_data_dir=tmp_dir)
+		profile_chromium = BrowserProfile(engine='chromium', user_data_dir=tmp_dir)
+		# Both should produce the same args since engine doesn't affect args yet
+		assert profile_default.get_args() == profile_chromium.get_args()


### PR DESCRIPTION
BrowserProvider ABC + ChromiumProvider + ProviderRegistry. Engine field on BrowserProfile. Purely additive, no behavior change. 17 tests.