### PR TITLE
feat(browser): Camoufox engine adapter + route-based selection (S6)

### DIFF
--- a/browser_use/browser/providers/__init__.py
+++ b/browser_use/browser/providers/__init__.py
@@ -2,12 +2,16 @@
 
 Exports:
 	BrowserProvider: Abstract base class for browser engines.
+	CamoufoxProvider: Camoufox (anti-detect Firefox) engine provider.
 	ChromiumProvider: Chromium/Chrome engine provider.
 	ProviderRegistry: Engine name -> provider class lookup.
+	RouteSelector: URL-based engine selection.
 """
 
 from browser_use.browser.providers.base import BrowserProvider
+from browser_use.browser.providers.camoufox import CamoufoxProvider
 from browser_use.browser.providers.chromium import ChromiumProvider
 from browser_use.browser.providers.registry import ProviderRegistry
+from browser_use.browser.providers.route_selector import RouteSelector
 
-__all__ = ['BrowserProvider', 'ChromiumProvider', 'ProviderRegistry']
+__all__ = ['BrowserProvider', 'CamoufoxProvider', 'ChromiumProvider', 'ProviderRegistry', 'RouteSelector']

--- a/browser_use/browser/providers/camoufox.py
+++ b/browser_use/browser/providers/camoufox.py
@@ -1,0 +1,280 @@
+"""Camoufox (anti-detect Firefox) browser engine provider.
+
+Launches Camoufox via its Python library and exposes a WebSocket endpoint
+for Playwright-based connection. Camoufox is a Firefox fork with built-in
+anti-fingerprinting; it uses the Juggler protocol (not CDP) under the hood,
+but provides a Playwright-compatible WebSocket server.
+
+Install: pip install camoufox && python -m camoufox fetch
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from browser_use.browser.providers.base import BrowserProvider
+from browser_use.utils import logger
+
+if TYPE_CHECKING:
+	from browser_use.browser.profile import BrowserProfile
+
+
+class CamoufoxProvider(BrowserProvider):
+	"""Launches Camoufox (anti-detect Firefox) browser.
+
+	Camoufox is a Firefox fork with engine-level anti-fingerprinting.
+	It wraps Playwright's Firefox launcher, so most stealth patches are
+	built in and fewer JS-level patches are needed compared to Chromium.
+
+	Two launch modes:
+	1. Library mode (preferred): Uses the camoufox Python package to
+	   launch via ``AsyncCamoufox`` context manager, returning a
+	   Playwright ``Browser`` object directly.
+	2. Subprocess mode (fallback): Launches the camoufox binary with
+	   ``--remote-debugging-port`` and waits for the endpoint.
+
+	Since browser-use's ``BrowserSession`` connects via CDP WebSocket,
+	this provider uses Camoufox's ``launch_server()`` to expose a
+	WebSocket endpoint that Playwright can connect to.
+	"""
+
+	def __init__(self) -> None:
+		self._process: asyncio.subprocess.Process | None = None
+		self._server: Any | None = None  # Camoufox server instance
+		self._ws_endpoint: str | None = None
+
+	@property
+	def engine_name(self) -> str:
+		"""Return engine identifier."""
+		return 'firefox'
+
+	@property
+	def supports_cdp(self) -> bool:
+		"""Camoufox uses Juggler (Playwright Firefox protocol), not CDP.
+
+		It exposes a Playwright-compatible WebSocket, but the underlying
+		protocol is NOT Chrome DevTools Protocol. Some CDP-specific
+		features (Fetch domain, DOM domain commands) may not work.
+		"""
+		return False
+
+	async def launch(self, profile: BrowserProfile) -> tuple[str, int | None]:
+		"""Launch Camoufox and return (ws_endpoint, pid).
+
+		Attempts to use the camoufox Python library first. Falls back
+		to subprocess launch if the library is not available.
+
+		Args:
+			profile: Browser profile with launch configuration.
+
+		Returns:
+			Tuple of (websocket_endpoint_url, process_pid_or_none).
+
+		Raises:
+			FileNotFoundError: If camoufox is not installed.
+		"""
+		# Try library-based launch first
+		ws_url, pid = await self._launch_via_library(profile)
+		if ws_url:
+			return ws_url, pid
+
+		# Fall back to subprocess launch
+		return await self._launch_via_subprocess(profile)
+
+	async def _launch_via_library(self, profile: BrowserProfile) -> tuple[str | None, int | None]:
+		"""Launch Camoufox using the Python library.
+
+		Returns (None, None) if the library is not installed.
+		"""
+		try:
+			from camoufox.server import launch_server
+		except ImportError:
+			return None, None
+
+		kwargs: dict[str, Any] = {}
+
+		if profile.headless:
+			kwargs['headless'] = True
+
+		# Camoufox launch_server returns a server with ws_endpoint
+		try:
+			self._server = await launch_server(**kwargs)
+			self._ws_endpoint = self._server.ws_endpoint
+			logger.debug(f'[CamoufoxProvider] Launched via library, ws={self._ws_endpoint}')
+			return self._ws_endpoint, None
+		except Exception as e:
+			logger.warning(f'[CamoufoxProvider] Library launch failed: {e}, trying subprocess')
+			self._server = None
+			return None, None
+
+	async def _launch_via_subprocess(self, profile: BrowserProfile) -> tuple[str, int | None]:
+		"""Launch Camoufox as a subprocess with remote debugging port.
+
+		Falls back to binary execution if the Python library is unavailable.
+
+		Raises:
+			FileNotFoundError: If the camoufox binary cannot be found.
+		"""
+		binary = self._find_camoufox_binary()
+		if binary is None:
+			raise FileNotFoundError(
+				'Camoufox binary not found. Install via: pip install camoufox && python -m camoufox fetch'
+			)
+
+		args = self.get_default_args(profile)
+
+		self._process = await asyncio.create_subprocess_exec(
+			binary,
+			*args,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+
+		port = 9222
+		ws_url = f'ws://127.0.0.1:{port}'
+
+		# Wait for the endpoint to become available
+		await self._wait_for_ws_endpoint(port, timeout=15.0)
+
+		logger.debug(f'[CamoufoxProvider] Launched subprocess pid={self._process.pid}, ws={ws_url}')
+		return ws_url, self._process.pid
+
+	async def kill(self) -> None:
+		"""Kill the Camoufox browser process and clean up."""
+		# Clean up library-launched server
+		if self._server is not None:
+			try:
+				await self._server.close()
+			except Exception:
+				pass
+			self._server = None
+
+		# Clean up subprocess
+		if self._process is not None and self._process.returncode is None:
+			try:
+				self._process.terminate()
+				await asyncio.wait_for(self._process.wait(), timeout=5.0)
+			except asyncio.TimeoutError:
+				try:
+					self._process.kill()
+				except ProcessLookupError:
+					pass
+			except ProcessLookupError:
+				pass
+			self._process = None
+
+		self._ws_endpoint = None
+
+	def get_default_args(self, profile: BrowserProfile) -> list[str]:
+		"""Get Firefox-style launch arguments for Camoufox.
+
+		Firefox uses different flag conventions than Chromium:
+		- ``-headless`` instead of ``--headless``
+		- ``-profile <dir>`` instead of ``--user-data-dir=<dir>``
+		- ``--remote-debugging-port=<port>`` (same as Chrome)
+
+		Args:
+			profile: Browser profile to derive arguments from.
+
+		Returns:
+			List of CLI arguments for the Camoufox binary.
+		"""
+		args: list[str] = []
+
+		args.append('--remote-debugging-port=9222')
+
+		if profile.headless:
+			args.append('-headless')
+
+		if profile.user_data_dir:
+			args.extend(['-profile', str(profile.user_data_dir)])
+
+		if profile.window_size:
+			args.append(f'--width={profile.window_size.width}')
+			args.append(f'--height={profile.window_size.height}')
+
+		return args
+
+	def _find_camoufox_binary(self) -> str | None:
+		"""Find the camoufox binary in common locations.
+
+		Searches:
+		1. PATH (via shutil.which)
+		2. ~/.camoufox/camoufox
+		3. ~/.local/bin/camoufox
+
+		Returns:
+			Path to the binary, or None if not found.
+		"""
+		# Check PATH
+		binary = shutil.which('camoufox')
+		if binary:
+			return binary
+
+		# Check common install locations
+		home = Path.home()
+		candidates = [
+			home / '.camoufox' / 'camoufox',
+			home / '.local' / 'bin' / 'camoufox',
+			# pip install camoufox puts it in the venv
+			Path(os.sys.prefix) / 'bin' / 'camoufox',
+		]
+		for path in candidates:
+			if path.exists() and path.is_file():
+				return str(path)
+
+		return None
+
+	async def _wait_for_ws_endpoint(self, port: int, timeout: float = 15.0) -> None:
+		"""Wait for the WebSocket endpoint to become available.
+
+		Polls the HTTP endpoint at the given port until it responds
+		or the timeout is reached.
+
+		Args:
+			port: The port to check.
+			timeout: Maximum seconds to wait.
+
+		Raises:
+			TimeoutError: If the endpoint is not available within the timeout.
+		"""
+		import urllib.request
+		import urllib.error
+
+		deadline = asyncio.get_event_loop().time() + timeout
+		url = f'http://127.0.0.1:{port}/json/version'
+
+		while asyncio.get_event_loop().time() < deadline:
+			try:
+				req = urllib.request.Request(url, method='GET')
+				with urllib.request.urlopen(req, timeout=1) as resp:
+					if resp.status == 200:
+						return
+			except (urllib.error.URLError, OSError, ConnectionError):
+				pass
+			await asyncio.sleep(0.3)
+
+		raise TimeoutError(f'Camoufox endpoint not available on port {port} after {timeout}s')
+
+	@classmethod
+	def is_available(cls) -> bool:
+		"""Check if Camoufox is installed and available.
+
+		Returns:
+			True if either the camoufox Python package or binary is found.
+		"""
+		# Check for Python library
+		try:
+			import camoufox  # noqa: F401
+
+			return True
+		except ImportError:
+			pass
+
+		# Check for binary
+		provider = cls()
+		return provider._find_camoufox_binary() is not None

--- a/browser_use/browser/providers/registry.py
+++ b/browser_use/browser/providers/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from browser_use.browser.providers.base import BrowserProvider
+from browser_use.browser.providers.camoufox import CamoufoxProvider
 from browser_use.browser.providers.chromium import ChromiumProvider
 
 
@@ -53,5 +54,6 @@ class ProviderRegistry:
 		return list(cls._providers.keys())
 
 
-# Auto-register the built-in chromium provider
+# Auto-register built-in providers
 ProviderRegistry.register('chromium', ChromiumProvider)
+ProviderRegistry.register('firefox', CamoufoxProvider)

--- a/browser_use/browser/providers/route_selector.py
+++ b/browser_use/browser/providers/route_selector.py
@@ -1,0 +1,132 @@
+"""Route-based browser engine selection.
+
+Maps target URL patterns to the optimal browser engine based on known
+anti-bot detection characteristics of various ATS platforms.
+
+This is a starting point -- routing rules will be refined based on
+real-world detection data from production runs.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+
+class RouteSelector:
+	"""Select browser engine based on target URL pattern.
+
+	Sites with aggressive Chromium bot detection route to Firefox/Camoufox.
+	Sites known to work well with Chromium stay on the default engine.
+	Unknown sites default to Chromium (widest compatibility).
+
+	Usage:
+		engine = RouteSelector.select_engine("https://company.myworkdayjobs.com/...")
+		# Returns "firefox" for Workday
+
+		engine = RouteSelector.select_engine("https://boards.greenhouse.io/...")
+		# Returns "chromium" for Greenhouse
+	"""
+
+	# Sites with aggressive Chromium bot detection -> prefer Firefox/Camoufox
+	FIREFOX_PREFERRED: dict[str, list[str]] = {
+		'workday': ['myworkdayjobs.com', 'myworkday.com', 'workday.com'],
+	}
+
+	# Sites that work better with Chromium (or have no special detection)
+	CHROMIUM_PREFERRED: dict[str, list[str]] = {
+		'greenhouse': ['greenhouse.io', 'boards.greenhouse.io'],
+		'lever': ['lever.co', 'jobs.lever.co'],
+		'icims': ['icims.com'],
+		'taleo': ['taleo.net'],
+		'successfactors': ['successfactors.com', 'successfactors.eu'],
+	}
+
+	@classmethod
+	def select_engine(cls, url: str, platform: str = '') -> str:
+		"""Return 'chromium' or 'firefox' based on URL and/or platform hint.
+
+		Resolution order:
+		1. If ``platform`` matches a known Firefox-preferred platform, return 'firefox'.
+		2. If URL domain matches a Firefox-preferred pattern, return 'firefox'.
+		3. If URL domain matches a Chromium-preferred pattern, return 'chromium'.
+		4. Default: 'chromium'.
+
+		Args:
+			url: Target URL to analyze.
+			platform: Optional platform hint (e.g., 'workday', 'greenhouse').
+
+		Returns:
+			Engine name: 'chromium' or 'firefox'.
+		"""
+		# Platform hint takes precedence
+		if platform:
+			platform_lower = platform.lower()
+			if platform_lower in cls.FIREFOX_PREFERRED:
+				return 'firefox'
+			if platform_lower in cls.CHROMIUM_PREFERRED:
+				return 'chromium'
+
+		# Extract domain from URL
+		domain = cls._extract_domain(url)
+		if not domain:
+			return 'chromium'
+
+		# Check Firefox-preferred domains
+		for _platform, domains in cls.FIREFOX_PREFERRED.items():
+			if any(domain.endswith(d) for d in domains):
+				return 'firefox'
+
+		# Check Chromium-preferred domains (explicit match, not strictly needed
+		# since chromium is the default, but useful for documentation and logging)
+		for _platform, domains in cls.CHROMIUM_PREFERRED.items():
+			if any(domain.endswith(d) for d in domains):
+				return 'chromium'
+
+		# Default to chromium (widest compatibility)
+		return 'chromium'
+
+	@classmethod
+	def get_platform_for_url(cls, url: str) -> str | None:
+		"""Identify the ATS platform for a given URL.
+
+		Args:
+			url: Target URL to analyze.
+
+		Returns:
+			Platform name (e.g., 'workday', 'greenhouse') or None.
+		"""
+		domain = cls._extract_domain(url)
+		if not domain:
+			return None
+
+		for platform, domains in {**cls.FIREFOX_PREFERRED, **cls.CHROMIUM_PREFERRED}.items():
+			if any(domain.endswith(d) for d in domains):
+				return platform
+
+		return None
+
+	@classmethod
+	def _extract_domain(cls, url: str) -> str:
+		"""Extract and normalize the domain from a URL.
+
+		Handles URLs with and without scheme. Returns empty string
+		for invalid/empty URLs.
+
+		Args:
+			url: URL to parse.
+
+		Returns:
+			Lowercase domain string, or empty string.
+		"""
+		if not url:
+			return ''
+
+		# urlparse needs a scheme to parse correctly
+		if not url.startswith(('http://', 'https://', '//')):
+			url = 'https://' + url
+
+		try:
+			hostname = urlparse(url).hostname
+			return (hostname or '').lower()
+		except Exception:
+			return ''

--- a/browser_use/browser/stealth/__init__.py
+++ b/browser_use/browser/stealth/__init__.py
@@ -1,0 +1,5 @@
+"""Stealth scripts for browser anti-detection.
+
+Engine-specific stealth patches are in separate modules:
+- firefox_scripts.py: Minimal patches for Camoufox (most stealth is engine-level)
+"""

--- a/browser_use/browser/stealth/firefox_scripts.py
+++ b/browser_use/browser/stealth/firefox_scripts.py
@@ -1,0 +1,117 @@
+"""Firefox/Camoufox stealth scripts.
+
+Camoufox has engine-level anti-fingerprinting built in, so it needs far
+fewer JS-level patches than Chromium. This module provides only the
+supplemental patches that enhance beyond Camoufox's defaults.
+
+These scripts are injected via Playwright's ``add_init_script()`` (or
+the CDP ``Page.addScriptToEvaluateOnNewDocument`` equivalent) and
+persist across navigations.
+
+Usage:
+    scripts = get_firefox_stealth_scripts(enabled=True)
+    for script in scripts:
+        await page.add_init_script(script)
+"""
+
+from __future__ import annotations
+
+# -- Supplemental patches for Camoufox ------------------------------------
+#
+# Camoufox already handles:
+#   - navigator.webdriver = undefined
+#   - WebGL fingerprint spoofing
+#   - Canvas fingerprint protection
+#   - AudioContext fingerprint protection
+#   - Font enumeration protection
+#   - Screen/window dimension normalization
+#
+# The patches below cover gaps that Camoufox doesn't address by default.
+
+PERMISSIONS_PATCH = """
+// Ensure Notification.permission returns 'default' (not 'denied')
+// Some sites check this as a bot signal since headless browsers deny all.
+(function() {
+    try {
+        if (typeof Notification !== 'undefined') {
+            Object.defineProperty(Notification, 'permission', {
+                get: function() { return 'default'; },
+                configurable: true
+            });
+        }
+    } catch(e) {}
+})();
+"""
+
+MEDIA_CODECS_PATCH = """
+// Ensure MediaSource.isTypeSupported returns true for common codecs.
+// Headless browsers sometimes report no codec support.
+(function() {
+    try {
+        if (typeof MediaSource !== 'undefined') {
+            const originalIsTypeSupported = MediaSource.isTypeSupported;
+            const commonCodecs = [
+                'video/mp4; codecs="avc1.42E01E"',
+                'video/mp4; codecs="avc1.42E01E, mp4a.40.2"',
+                'video/webm; codecs="vp8"',
+                'video/webm; codecs="vp9"',
+                'audio/mp4; codecs="mp4a.40.2"',
+                'audio/webm; codecs="opus"',
+            ];
+            MediaSource.isTypeSupported = function(type) {
+                if (commonCodecs.some(c => type.includes(c.split(';')[0]))) {
+                    return true;
+                }
+                return originalIsTypeSupported.call(this, type);
+            };
+        }
+    } catch(e) {}
+})();
+"""
+
+TIMEZONE_CONSISTENCY_PATCH = """
+// Ensure Date timezone methods are consistent.
+// Some detection scripts compare Intl.DateTimeFormat timezone with
+// Date.getTimezoneOffset() to detect spoofing.
+(function() {
+    try {
+        // Only patch if there's no timezone override already set
+        const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        if (!tz) return;  // Let Camoufox handle it
+    } catch(e) {}
+})();
+"""
+
+
+def get_firefox_stealth_scripts(enabled: bool = True) -> list[str]:
+    """Return list of stealth JS scripts for Firefox/Camoufox.
+
+    Camoufox has extensive built-in stealth, so this returns a minimal
+    set of supplemental patches. Returns an empty list if disabled.
+
+    Args:
+        enabled: Whether stealth patches are enabled.
+
+    Returns:
+        List of JavaScript strings to inject.
+    """
+    if not enabled:
+        return []
+
+    return [
+        PERMISSIONS_PATCH,
+        MEDIA_CODECS_PATCH,
+        TIMEZONE_CONSISTENCY_PATCH,
+    ]
+
+
+def is_firefox_engine(engine_name: str) -> bool:
+    """Check if the given engine name represents Firefox/Camoufox.
+
+    Args:
+        engine_name: Engine identifier string.
+
+    Returns:
+        True if the engine is Firefox-based.
+    """
+    return engine_name.lower() in ('firefox', 'camoufox')

--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -94,6 +94,14 @@ def parse_args() -> argparse.Namespace:
     # Playwright
     parser.add_argument("--browsers-path", default=None, help="Path to Playwright browser binaries")
 
+    # Browser engine
+    parser.add_argument(
+        "--engine",
+        choices=["chromium", "firefox", "auto"],
+        default="auto",
+        help="Browser engine to use: chromium, firefox (Camoufox), or auto (route-based selection, default)",
+    )
+
     return parser.parse_args(argv)
 
 
@@ -223,6 +231,14 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
     if args.email and args.password:
         sensitive_data = {"email": args.email, "password": args.password}
 
+    # -- Engine selection ---------------------------------------------------
+    engine = args.engine
+    if engine == "auto":
+        from browser_use.browser.providers.route_selector import RouteSelector
+
+        engine = RouteSelector.select_engine(args.job_url, platform)
+        emit_status(f"Auto-selected browser engine: {engine}", job_id=args.job_id)
+
     # -- Browser ------------------------------------------------------------
     browser_profile = BrowserProfile(
         headless=args.headless,
@@ -231,6 +247,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
         demo_mode=False,
         interaction_highlight_color="rgb(37, 99, 235)",
         wait_between_actions=settings.wait_between_actions,
+        engine=engine,
     )
     browser = BrowserSession(browser_profile=browser_profile)
 
@@ -422,6 +439,14 @@ async def run_agent_human(args: argparse.Namespace) -> None:
     if args.email and args.password:
         sensitive_data = {"email": args.email, "password": args.password}
 
+    # -- Engine selection ---------------------------------------------------
+    engine = args.engine
+    if engine == "auto":
+        from browser_use.browser.providers.route_selector import RouteSelector
+
+        engine = RouteSelector.select_engine(args.job_url, platform)
+        print(f"Auto-selected browser engine: {engine}")
+
     # -- Browser ------------------------------------------------------------
     browser_profile = BrowserProfile(
         headless=args.headless,
@@ -430,6 +455,7 @@ async def run_agent_human(args: argparse.Namespace) -> None:
         demo_mode=False,
         interaction_highlight_color="rgb(37, 99, 235)",
         wait_between_actions=settings.wait_between_actions,
+        engine=engine,
     )
     browser = BrowserSession(browser_profile=browser_profile)
 

--- a/tests/ci/browser/test_browser_provider.py
+++ b/tests/ci/browser/test_browser_provider.py
@@ -23,10 +23,12 @@ class TestProviderRegistry:
 		provider_cls = ProviderRegistry.get('chromium')
 		assert provider_cls is ChromiumProvider
 
-	def test_get_firefox_raises_not_implemented(self):
-		"""ProviderRegistry.get('firefox') must raise NotImplementedError (not yet registered)."""
-		with pytest.raises(NotImplementedError, match="Browser provider 'firefox' not registered"):
-			ProviderRegistry.get('firefox')
+	def test_get_firefox_returns_camoufox_provider(self):
+		"""ProviderRegistry.get('firefox') must return CamoufoxProvider (registered in S6)."""
+		from browser_use.browser.providers.camoufox import CamoufoxProvider
+
+		provider_cls = ProviderRegistry.get('firefox')
+		assert provider_cls is CamoufoxProvider
 
 	def test_get_unknown_raises_not_implemented(self):
 		"""ProviderRegistry.get with an unknown name raises NotImplementedError."""

--- a/tests/ci/browser/test_camoufox_provider.py
+++ b/tests/ci/browser/test_camoufox_provider.py
@@ -1,0 +1,228 @@
+"""Tests for CamoufoxProvider (Stream 6).
+
+Validates:
+- CamoufoxProvider properties and interface
+- ProviderRegistry correctly registers and retrieves CamoufoxProvider
+- CamoufoxProvider.get_default_args() returns Firefox-style args
+- BrowserProfile(engine='firefox') creates a valid profile
+- CamoufoxProvider graceful handling when Camoufox is not installed
+
+All tests are designed to work WITHOUT Camoufox installed (for CI).
+Tests that require a running Camoufox instance are marked with skipif.
+"""
+
+import shutil
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.providers import BrowserProvider, CamoufoxProvider, ProviderRegistry
+
+
+class TestCamoufoxProviderProperties:
+	"""Tests for CamoufoxProvider properties and interface compliance."""
+
+	def test_engine_name_is_firefox(self):
+		"""CamoufoxProvider.engine_name must be 'firefox'."""
+		provider = CamoufoxProvider()
+		assert provider.engine_name == 'firefox'
+
+	def test_supports_cdp_is_false(self):
+		"""CamoufoxProvider.supports_cdp must be False (uses Juggler, not CDP)."""
+		provider = CamoufoxProvider()
+		assert provider.supports_cdp is False
+
+	def test_is_subclass_of_browser_provider(self):
+		"""CamoufoxProvider must be a subclass of BrowserProvider."""
+		assert issubclass(CamoufoxProvider, BrowserProvider)
+
+	def test_instance_starts_clean(self):
+		"""A fresh CamoufoxProvider instance has no process or server."""
+		provider = CamoufoxProvider()
+		assert provider._process is None
+		assert provider._server is None
+		assert provider._ws_endpoint is None
+
+
+class TestCamoufoxProviderArgs:
+	"""Tests for CamoufoxProvider.get_default_args() output."""
+
+	def test_get_default_args_returns_list(self):
+		"""get_default_args() must return a list of strings."""
+		provider = CamoufoxProvider()
+		profile = BrowserProfile()
+		args = provider.get_default_args(profile)
+		assert isinstance(args, list)
+		assert all(isinstance(arg, str) for arg in args)
+
+	def test_get_default_args_includes_debug_port(self):
+		"""get_default_args() must include --remote-debugging-port."""
+		provider = CamoufoxProvider()
+		profile = BrowserProfile()
+		args = provider.get_default_args(profile)
+		assert any(arg.startswith('--remote-debugging-port=') for arg in args)
+
+	def test_get_default_args_default_port_9222(self):
+		"""Default debug port is 9222 when not specified in profile."""
+		provider = CamoufoxProvider()
+		profile = BrowserProfile()
+		args = provider.get_default_args(profile)
+		assert '--remote-debugging-port=9222' in args
+
+	def test_get_default_args_headless_flag(self):
+		"""headless=True adds -headless (Firefox-style, no --)."""
+		provider = CamoufoxProvider()
+		profile = BrowserProfile(headless=True)
+		args = provider.get_default_args(profile)
+		assert '-headless' in args
+		# Must NOT use Chrome-style --headless
+		assert '--headless' not in args
+
+	def test_get_default_args_no_headless_flag_when_false(self):
+		"""headless=False does NOT add -headless flag."""
+		provider = CamoufoxProvider()
+		profile = BrowserProfile(headless=False)
+		args = provider.get_default_args(profile)
+		assert '-headless' not in args
+
+	def test_get_default_args_user_data_dir_as_profile(self):
+		"""user_data_dir uses -profile (Firefox-style, not --user-data-dir).
+
+		BrowserProfile resolves paths via Path.resolve(), so the arg value
+		matches profile.user_data_dir (the resolved path), not the raw input.
+		"""
+		import tempfile
+
+		tmp_dir = tempfile.mkdtemp(prefix='camoufox-test-')
+		provider = CamoufoxProvider()
+		profile = BrowserProfile(user_data_dir=tmp_dir)
+		args = provider.get_default_args(profile)
+		assert '-profile' in args
+		idx = args.index('-profile')
+		# Must match the resolved user_data_dir from the profile
+		assert args[idx + 1] == str(profile.user_data_dir)
+		# Must NOT use Chrome-style --user-data-dir
+		assert not any(arg.startswith('--user-data-dir=') for arg in args)
+
+	def test_get_default_args_window_size(self):
+		"""window_size adds --width and --height flags.
+
+		Note: headless=False is required because BrowserProfile's
+		detect_display_configuration() sets window_size=None in headless mode.
+		"""
+		from browser_use.browser.profile import ViewportSize
+
+		provider = CamoufoxProvider()
+		profile = BrowserProfile(headless=False, window_size=ViewportSize(width=1920, height=1080))
+		args = provider.get_default_args(profile)
+		assert '--width=1920' in args
+		assert '--height=1080' in args
+
+
+class TestCamoufoxRegistration:
+	"""Tests for CamoufoxProvider registration in ProviderRegistry."""
+
+	def test_registry_get_firefox_returns_camoufox(self):
+		"""ProviderRegistry.get('firefox') must return CamoufoxProvider."""
+		provider_cls = ProviderRegistry.get('firefox')
+		assert provider_cls is CamoufoxProvider
+
+	def test_registry_available_includes_firefox(self):
+		"""ProviderRegistry.available() must include 'firefox'."""
+		available = ProviderRegistry.available()
+		assert 'firefox' in available
+
+	def test_registry_available_includes_both_engines(self):
+		"""ProviderRegistry.available() must include both 'chromium' and 'firefox'."""
+		available = ProviderRegistry.available()
+		assert 'chromium' in available
+		assert 'firefox' in available
+
+	def test_registry_instantiate_firefox_provider(self):
+		"""Can instantiate a CamoufoxProvider from the registry."""
+		provider_cls = ProviderRegistry.get('firefox')
+		provider = provider_cls()
+		assert isinstance(provider, CamoufoxProvider)
+		assert provider.engine_name == 'firefox'
+
+
+class TestCamoufoxBrowserProfile:
+	"""Tests for BrowserProfile with engine='firefox'."""
+
+	def test_engine_firefox_valid(self):
+		"""BrowserProfile(engine='firefox') is valid."""
+		profile = BrowserProfile(engine='firefox')
+		assert profile.engine == 'firefox'
+
+	def test_engine_firefox_headless(self):
+		"""BrowserProfile(engine='firefox', headless=True) is valid."""
+		profile = BrowserProfile(engine='firefox', headless=True)
+		assert profile.engine == 'firefox'
+		assert profile.headless is True
+
+	def test_engine_auto_valid(self):
+		"""BrowserProfile(engine='auto') is valid."""
+		profile = BrowserProfile(engine='auto')
+		assert profile.engine == 'auto'
+
+
+class TestCamoufoxKill:
+	"""Tests for CamoufoxProvider.kill() cleanup."""
+
+	@pytest.mark.asyncio
+	async def test_kill_no_process_is_safe(self):
+		"""Calling kill() on a fresh provider (no process) must not raise."""
+		provider = CamoufoxProvider()
+		# Should not raise
+		await provider.kill()
+		assert provider._process is None
+		assert provider._server is None
+		assert provider._ws_endpoint is None
+
+
+class TestCamoufoxAvailability:
+	"""Tests for CamoufoxProvider.is_available() class method."""
+
+	def test_is_available_returns_bool(self):
+		"""is_available() must return a boolean."""
+		result = CamoufoxProvider.is_available()
+		assert isinstance(result, bool)
+
+	@pytest.mark.skipif(shutil.which('camoufox') is not None, reason='Camoufox IS installed')
+	def test_find_binary_returns_none_when_not_installed(self):
+		"""_find_camoufox_binary() returns None when camoufox is not in PATH."""
+		provider = CamoufoxProvider()
+		# May still find it in ~/.camoufox or venv, so this test
+		# only asserts the return type
+		result = provider._find_camoufox_binary()
+		assert result is None or isinstance(result, str)
+
+
+@pytest.mark.skipif(not shutil.which('camoufox'), reason='Camoufox not installed')
+class TestCamoufoxLaunch:
+	"""Tests that require Camoufox to be installed.
+
+	These tests are skipped in CI if Camoufox is not available.
+	"""
+
+	@pytest.mark.asyncio
+	async def test_launch_returns_ws_url_and_pid(self):
+		"""launch() must return a WebSocket URL and optional PID."""
+		provider = CamoufoxProvider()
+		try:
+			ws_url, pid = await provider.launch(BrowserProfile(headless=True))
+			assert isinstance(ws_url, str)
+			assert 'ws://' in ws_url or 'wss://' in ws_url
+		finally:
+			await provider.kill()
+
+	@pytest.mark.asyncio
+	async def test_launch_and_kill_lifecycle(self):
+		"""Full launch -> kill lifecycle must not leak processes."""
+		provider = CamoufoxProvider()
+		try:
+			await provider.launch(BrowserProfile(headless=True))
+		finally:
+			await provider.kill()
+		assert provider._process is None
+		assert provider._server is None

--- a/tests/ci/browser/test_route_selector.py
+++ b/tests/ci/browser/test_route_selector.py
@@ -1,0 +1,188 @@
+"""Tests for RouteSelector URL-to-engine routing (Stream 6).
+
+Validates:
+- Workday URLs route to 'firefox'
+- Greenhouse, Lever, iCIMS URLs route to 'chromium'
+- Unknown URLs default to 'chromium'
+- Empty/invalid URLs default to 'chromium'
+- Platform hint overrides URL matching
+- Domain extraction handles edge cases
+"""
+
+import pytest
+
+from browser_use.browser.providers.route_selector import RouteSelector
+
+
+class TestFirefoxPreferred:
+	"""Workday and other Firefox-preferred sites must route to firefox."""
+
+	def test_workday_myworkdayjobs(self):
+		"""myworkdayjobs.com -> firefox."""
+		assert RouteSelector.select_engine('https://company.myworkdayjobs.com/en-US/jobs') == 'firefox'
+
+	def test_workday_myworkday(self):
+		"""myworkday.com -> firefox."""
+		assert RouteSelector.select_engine('https://app.myworkday.com/login') == 'firefox'
+
+	def test_workday_main_domain(self):
+		"""workday.com -> firefox."""
+		assert RouteSelector.select_engine('https://www.workday.com/careers') == 'firefox'
+
+	def test_workday_subdomain(self):
+		"""Subdomains of workday.com -> firefox."""
+		assert RouteSelector.select_engine('https://jobs.workday.com/posting/12345') == 'firefox'
+
+	def test_workday_with_path(self):
+		"""Full Workday URL with path components -> firefox."""
+		url = 'https://acme.myworkdayjobs.com/en-US/External/job/San-Francisco/Software-Engineer_R123456'
+		assert RouteSelector.select_engine(url) == 'firefox'
+
+
+class TestChromiumPreferred:
+	"""Greenhouse, Lever, and other Chromium-preferred sites."""
+
+	def test_greenhouse_boards(self):
+		"""boards.greenhouse.io -> chromium."""
+		assert RouteSelector.select_engine('https://boards.greenhouse.io/company/jobs/12345') == 'chromium'
+
+	def test_greenhouse_main(self):
+		"""greenhouse.io -> chromium."""
+		assert RouteSelector.select_engine('https://greenhouse.io/something') == 'chromium'
+
+	def test_lever_jobs(self):
+		"""jobs.lever.co -> chromium."""
+		assert RouteSelector.select_engine('https://jobs.lever.co/company/12345') == 'chromium'
+
+	def test_lever_main(self):
+		"""lever.co -> chromium."""
+		assert RouteSelector.select_engine('https://lever.co/careers') == 'chromium'
+
+	def test_icims(self):
+		"""icims.com -> chromium."""
+		assert RouteSelector.select_engine('https://careers.icims.com/jobs/12345') == 'chromium'
+
+	def test_taleo(self):
+		"""taleo.net -> chromium."""
+		assert RouteSelector.select_engine('https://company.taleo.net/careersection/') == 'chromium'
+
+	def test_successfactors(self):
+		"""successfactors.com -> chromium."""
+		assert RouteSelector.select_engine('https://company.successfactors.com/career') == 'chromium'
+
+
+class TestDefaultBehavior:
+	"""Unknown and edge-case URLs default to chromium."""
+
+	def test_unknown_domain(self):
+		"""Unknown domain -> chromium (default)."""
+		assert RouteSelector.select_engine('https://example.com/careers') == 'chromium'
+
+	def test_empty_url(self):
+		"""Empty URL -> chromium (default)."""
+		assert RouteSelector.select_engine('') == 'chromium'
+
+	def test_none_like_empty_string(self):
+		"""Empty string -> chromium (default)."""
+		assert RouteSelector.select_engine('') == 'chromium'
+
+	def test_url_without_scheme(self):
+		"""URL without scheme is handled gracefully."""
+		assert RouteSelector.select_engine('company.myworkdayjobs.com/jobs') == 'firefox'
+
+	def test_random_ats_site(self):
+		"""Non-listed ATS -> chromium (default)."""
+		assert RouteSelector.select_engine('https://apply.smartrecruiters.com/') == 'chromium'
+
+	def test_localhost(self):
+		"""localhost URL -> chromium (default)."""
+		assert RouteSelector.select_engine('http://localhost:3000/jobs') == 'chromium'
+
+	def test_ip_address_url(self):
+		"""IP address URL -> chromium (default)."""
+		assert RouteSelector.select_engine('http://192.168.1.1:8080/careers') == 'chromium'
+
+
+class TestPlatformHint:
+	"""Platform hint should take precedence over URL matching."""
+
+	def test_platform_workday_overrides(self):
+		"""platform='workday' -> firefox, even with non-matching URL."""
+		assert RouteSelector.select_engine('https://example.com', platform='workday') == 'firefox'
+
+	def test_platform_greenhouse_overrides(self):
+		"""platform='greenhouse' -> chromium."""
+		assert RouteSelector.select_engine('https://example.com', platform='greenhouse') == 'chromium'
+
+	def test_platform_unknown_falls_to_url(self):
+		"""Unknown platform falls back to URL matching."""
+		assert RouteSelector.select_engine('https://company.myworkdayjobs.com', platform='unknown') == 'firefox'
+
+	def test_platform_case_insensitive(self):
+		"""Platform hint is case-insensitive."""
+		assert RouteSelector.select_engine('https://example.com', platform='Workday') == 'firefox'
+		assert RouteSelector.select_engine('https://example.com', platform='WORKDAY') == 'firefox'
+
+	def test_empty_platform_ignored(self):
+		"""Empty platform string is ignored."""
+		assert RouteSelector.select_engine('https://company.myworkdayjobs.com', platform='') == 'firefox'
+
+
+class TestGetPlatformForUrl:
+	"""Tests for RouteSelector.get_platform_for_url()."""
+
+	def test_workday_detected(self):
+		"""Workday URL returns 'workday' platform."""
+		assert RouteSelector.get_platform_for_url('https://company.myworkdayjobs.com/jobs') == 'workday'
+
+	def test_greenhouse_detected(self):
+		"""Greenhouse URL returns 'greenhouse' platform."""
+		assert RouteSelector.get_platform_for_url('https://boards.greenhouse.io/company') == 'greenhouse'
+
+	def test_lever_detected(self):
+		"""Lever URL returns 'lever' platform."""
+		assert RouteSelector.get_platform_for_url('https://jobs.lever.co/company') == 'lever'
+
+	def test_unknown_returns_none(self):
+		"""Unknown URL returns None."""
+		assert RouteSelector.get_platform_for_url('https://example.com') is None
+
+	def test_empty_url_returns_none(self):
+		"""Empty URL returns None."""
+		assert RouteSelector.get_platform_for_url('') is None
+
+
+class TestDomainExtraction:
+	"""Tests for RouteSelector._extract_domain() edge cases."""
+
+	def test_https_url(self):
+		"""Standard HTTPS URL."""
+		assert RouteSelector._extract_domain('https://example.com/path') == 'example.com'
+
+	def test_http_url(self):
+		"""Standard HTTP URL."""
+		assert RouteSelector._extract_domain('http://example.com') == 'example.com'
+
+	def test_url_with_port(self):
+		"""URL with port number."""
+		assert RouteSelector._extract_domain('https://example.com:8080/path') == 'example.com'
+
+	def test_url_without_scheme(self):
+		"""URL without scheme gets https:// prepended."""
+		assert RouteSelector._extract_domain('example.com/path') == 'example.com'
+
+	def test_subdomain_preserved(self):
+		"""Subdomains are preserved."""
+		assert RouteSelector._extract_domain('https://sub.example.com') == 'sub.example.com'
+
+	def test_empty_string(self):
+		"""Empty string returns empty string."""
+		assert RouteSelector._extract_domain('') == ''
+
+	def test_uppercase_normalized(self):
+		"""Domain is lowercased."""
+		assert RouteSelector._extract_domain('https://EXAMPLE.COM') == 'example.com'
+
+	def test_protocol_relative_url(self):
+		"""Protocol-relative URL (//example.com)."""
+		assert RouteSelector._extract_domain('//example.com/path') == 'example.com'


### PR DESCRIPTION
CamoufoxProvider (Firefox anti-detect), RouteSelector (Workday→Firefox, Greenhouse→Chromium), --engine CLI flag, Firefox stealth scripts. Depends on S5. 75 tests (2 skipped without Camoufox).