### PR TITLE
fix(security): round 2 hardening — data URI, PII, domain freeze, budget guard

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -68,8 +68,7 @@ class SecurityWatchdog(BaseWatchdog):
 				await session.cdp_client.send.Page.navigate(params={'url': 'about:blank'}, session_id=session.session_id)
 				self.logger.info(f'⛔️ Navigated to about:blank after blocked URL: {event.url}')
 			except Exception as e:
-				pass
-				self.logger.error(f'⛔️ Failed to navigate to about:blank: {type(e).__name__} {e}')
+				self.logger.error(f'⛔️ Failed to navigate to about:blank after blocked redirect: {type(e).__name__} {e}')
 
 	async def on_TabCreatedEvent(self, event: TabCreatedEvent) -> None:
 		"""Check if new tab URL is allowed."""
@@ -179,8 +178,16 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
-		# Allow data: and blob: URLs (they don't have hostnames)
-		if parsed.scheme in ['data', 'blob']:
+		# Allow blob: URLs (origin-bound, safe)
+		if parsed.scheme == 'blob':
+			return True
+
+		# Allow data: URLs only for non-executable MIME types (images, fonts, etc.)
+		# Block data:text/html which can execute JS for credential exfiltration
+		if parsed.scheme == 'data':
+			data_content = url.split(',', 1)[0].lower()
+			if 'text/html' in data_content or 'application/javascript' in data_content or 'text/javascript' in data_content:
+				return False
 			return True
 
 		# Get the actual host (domain)

--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -32,12 +32,15 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import atexit
 import contextlib
 import json
 import logging
 import os
 import signal
+import stat
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -65,6 +68,10 @@ os.environ["BROWSER_USE_SETUP_LOGGING"] = "false"
 from ghosthands.agent.hooks import install_same_tab_guard
 
 logger = structlog.get_logger()
+
+# Pre-step budget guard: estimated cost of one agent step in USD.
+# If remaining budget is less than this, the agent stops before the next step.
+_STEP_COST_ESTIMATE = 0.10
 
 # ── Argument parsing ──────────────────────────────────────────────────
 
@@ -194,6 +201,13 @@ def _load_profile(args: argparse.Namespace) -> dict:
     if profile_text:
         return _validate_profile(json.loads(profile_text))
 
+    # File-based profile fallback
+    profile_path = os.environ.get("GH_USER_PROFILE_PATH", "")
+    if profile_path:
+        p = Path(profile_path)
+        if p.is_file():
+            return _validate_profile(json.loads(p.read_text(encoding="utf-8")))
+
     raise ValueError("Either --profile, --test-data, or GH_USER_PROFILE_TEXT env var is required")
 
 
@@ -209,14 +223,32 @@ def _apply_runtime_env(
     if args.browsers_path:
         os.environ["PLAYWRIGHT_BROWSERS_PATH"] = args.browsers_path
 
-    os.environ["GH_USER_PROFILE_TEXT"] = json.dumps(profile, indent=2)
-    os.environ["GH_USER_PROFILE_JSON"] = json.dumps(profile)
+    # Write profile to temp file instead of env var (avoids /proc/pid/environ exposure)
+    profile_fd, profile_path = tempfile.mkstemp(prefix="gh_profile_", suffix=".json")
+    try:
+        os.fchmod(profile_fd, stat.S_IRUSR | stat.S_IWUSR)  # 0600
+        os.write(profile_fd, json.dumps(profile, indent=2).encode())
+        os.close(profile_fd)
+        os.environ["GH_USER_PROFILE_PATH"] = profile_path
+        atexit.register(_cleanup_profile_tempfile)
+    except Exception:
+        os.close(profile_fd)
+        os.unlink(profile_path)
+        raise
 
     resume_path = str(Path(args.resume).resolve()) if args.resume else ""
     if resume_path:
         os.environ["GH_RESUME_PATH"] = resume_path
 
     return resume_path
+
+
+def _cleanup_profile_tempfile() -> None:
+    """Remove the temporary profile file created by _apply_runtime_env."""
+    profile_path = os.environ.pop("GH_USER_PROFILE_PATH", "")
+    if profile_path:
+        with contextlib.suppress(OSError):
+            os.unlink(profile_path)
 
 
 def _load_runtime_settings():
@@ -572,6 +604,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
     from ghosthands.security.domain_lockdown import DomainLockdown
 
     lockdown = DomainLockdown(job_url=args.job_url, platform=platform)
+    lockdown.freeze()
     allowed_domains = lockdown.get_allowed_domains()
 
     # -- Browser ------------------------------------------------------------
@@ -639,6 +672,10 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
         if usage and usage.total_cost and usage.total_cost >= args.max_budget:
             ag.state.stopped = True
             emit_error("Budget exceeded", fatal=False, job_id=job_id)
+
+        # Pre-step budget guard: stop if less than estimated step cost remaining
+        if usage and usage.total_cost and (args.max_budget - usage.total_cost) < _STEP_COST_ESTIMATE:
+            ag.state.stopped = True
 
     # -- Run ----------------------------------------------------------------
     try:
@@ -874,18 +911,26 @@ async def run_agent_human(args: argparse.Namespace) -> None:
     # -- Credentials --------------------------------------------------------
     sensitive_data = _resolve_sensitive_data(app_settings, embedded_credentials, platform=platform)
 
+    # -- Domain lockdown ----------------------------------------------------
+    from ghosthands.security.domain_lockdown import DomainLockdown
+
+    lockdown = DomainLockdown(job_url=args.job_url, platform=platform)
+    lockdown.freeze()
+    allowed_domains = lockdown.get_allowed_domains()
+
     # -- Browser ------------------------------------------------------------
     cdp_url = args.cdp_url or os.environ.get("GH_CDP_URL")
     desktop_owns_browser = cdp_url is not None
 
     if cdp_url:
-        browser_profile = BrowserProfile(keep_alive=True)
+        browser_profile = BrowserProfile(keep_alive=True, allowed_domains=allowed_domains)
         browser = BrowserSession(browser_profile=browser_profile, cdp_url=cdp_url)
         print(f"Connecting to Desktop-owned browser via CDP: {cdp_url}")
     else:
         browser_profile = BrowserProfile(
             headless=args.headless,
             keep_alive=True,
+            allowed_domains=allowed_domains,
             aboutblank_loading_logo_enabled=True,
             demo_mode=False,
             interaction_highlight_color="rgb(37, 99, 235)",

--- a/ghosthands/security/domain_lockdown.py
+++ b/ghosthands/security/domain_lockdown.py
@@ -176,6 +176,7 @@ class DomainLockdown:
 		self._blocked_urls: deque[str] = deque(maxlen=20)
 		self._allow_cross_origin_resources = allow_cross_origin_resources
 		self._on_blocked = on_blocked
+		self._frozen = False
 
 		# Add the job URL's domain
 		job_domain = _extract_domain(job_url)
@@ -241,8 +242,14 @@ class DomainLockdown:
 		self._record_blocked(url, reason)
 		return False
 
+	def freeze(self) -> None:
+		"""Prevent further domain additions after initialization."""
+		self._frozen = True
+
 	def add_allowed_domain(self, domain: str) -> None:
 		"""Add a domain to the allowlist at runtime."""
+		if self._frozen:
+			raise RuntimeError("Cannot add domains after lockdown is frozen")
 		self._allowed_domains.add(domain.lower())
 
 	def get_allowed_domains(self) -> list[str]:

--- a/ghosthands/worker/executor.py
+++ b/ghosthands/worker/executor.py
@@ -8,7 +8,9 @@ database and VALET.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+import os
 import traceback
 from typing import Any
 from urllib.parse import urlparse
@@ -67,18 +69,25 @@ def validate_domain(url: str, allowed_domains: list[str]) -> bool:
 
 # ── Heartbeat task ────────────────────────────────────────────────────────
 
+HEARTBEAT_INTERVAL = 30
+HEARTBEAT_JITTER = 5
 
-async def _heartbeat_loop(db: Database, job_id: str, interval: float = 30.0) -> None:
+
+async def _heartbeat_loop(db: Database, job_id: str) -> None:
     """Background task that updates the heartbeat timestamp periodically.
 
     Runs until cancelled. Prevents the stuck-job recovery from reclaiming
-    our job while it's still running.
+    our job while it's still running. Includes random jitter to avoid
+    thundering-herd heartbeats across multiple workers.
     """
+    import random
+
     while True:
         try:
             await db.heartbeat(job_id)
         except Exception as exc:
             logger.warning("executor.heartbeat_failed", job_id=job_id, error=str(exc))
+        interval = HEARTBEAT_INTERVAL + random.uniform(0, HEARTBEAT_JITTER)
         await asyncio.sleep(interval)
 
 
@@ -361,7 +370,11 @@ async def _run_agent(
     Creates a fully-configured agent via the factory, runs it against the
     target URL, and returns structured results.
     """
-    import os
+    # ── Set profile env var for domhand_fill ──────────────────────
+    # domhand_fill reads GH_USER_PROFILE_PATH to generate field answers.
+    # Write to temp file instead of env var to avoid /proc/pid/environ exposure.
+    import stat
+    import tempfile
 
     from ghosthands.agent.factory import run_job_agent
     from ghosthands.agent.prompts import (
@@ -370,11 +383,17 @@ async def _run_agent(
         build_completion_detection_text,
     )
 
-    # ── Set profile env var for domhand_fill ──────────────────────
-    # domhand_fill reads GH_USER_PROFILE_TEXT to generate field answers.
     profile = resume_profile or {}
-    os.environ["GH_USER_PROFILE_TEXT"] = json.dumps(profile, indent=2)
-    os.environ["GH_USER_PROFILE_JSON"] = json.dumps(profile)
+    profile_fd, profile_path = tempfile.mkstemp(prefix="gh_profile_", suffix=".json")
+    try:
+        os.fchmod(profile_fd, stat.S_IRUSR | stat.S_IWUSR)  # 0600
+        os.write(profile_fd, json.dumps(profile, indent=2).encode())
+        os.close(profile_fd)
+        os.environ["GH_USER_PROFILE_PATH"] = profile_path
+    except Exception:
+        os.close(profile_fd)
+        os.unlink(profile_path)
+        raise
 
     # ── Build task prompt ────────────────────────────────────────
     resume_path = input_data.get("resume_path", "")
@@ -483,17 +502,23 @@ Other rules:
     log.info("executor.launching_agent", platform=platform, headless=settings.headless)
 
     # ── Run the agent ────────────────────────────────────────────
-    result = await run_job_agent(
-        task=task,
-        resume_profile=profile,
-        credentials=credentials,
-        platform=platform,
-        headless=settings.headless,
-        max_steps=settings.max_steps_per_job,
-        job_id=job_id,
-        max_budget=settings.max_budget_per_job,
-        on_status_update=_on_status,
-    )
+    try:
+        result = await run_job_agent(
+            task=task,
+            resume_profile=profile,
+            credentials=credentials,
+            platform=platform,
+            headless=settings.headless,
+            max_steps=settings.max_steps_per_job,
+            job_id=job_id,
+            max_budget=settings.max_budget_per_job,
+            on_status_update=_on_status,
+        )
+    finally:
+        # Clean up PII temp file
+        with contextlib.suppress(OSError):
+            os.unlink(profile_path)
+        os.environ.pop("GH_USER_PROFILE_PATH", None)
 
     log.info(
         "executor.agent_finished",


### PR DESCRIPTION
## Summary
- **P0**: Block data:text/html and data:application/javascript URLs in security watchdog
- **P1**: Fix dead code in security watchdog
- **P1**: Add freeze() to DomainLockdown — prevents runtime domain injection
- **P1**: Move user profile from env vars to 0600 temp files (PII protection)
- **P1**: Apply domain lockdown in run_agent_human mode
- **P2**: Heartbeat jitter (0-5s) to prevent thundering-herd
- **P2**: Pre-step budget guard ($0.10 remaining threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)