### PR TITLE
fix(security): data URI allowlist, profile loading order (#20)

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -182,13 +182,18 @@ class SecurityWatchdog(BaseWatchdog):
 		if parsed.scheme == 'blob':
 			return True
 
-		# Allow data: URLs only for non-executable MIME types (images, fonts, etc.)
-		# Block data:text/html which can execute JS for credential exfiltration
+		# Allow data: URLs only for known-safe MIME types (images, fonts, audio, video).
+		# Allowlist approach — blocks everything not explicitly safe, including
+		# image/svg+xml, application/xhtml+xml, text/xml which can contain scripts.
 		if parsed.scheme == 'data':
-			data_content = url.split(',', 1)[0].lower()
-			if 'text/html' in data_content or 'application/javascript' in data_content or 'text/javascript' in data_content:
+			data_header = url.split(',', 1)[0].lower()
+			safe_prefixes = ('data:image/', 'data:font/', 'data:audio/', 'data:video/', 'data:application/font-', 'data:application/octet-stream')
+			# SVG can execute scripts — explicitly exclude even though it starts with image/
+			if 'image/svg' in data_header:
 				return False
-			return True
+			if any(data_header.startswith(p) for p in safe_prefixes):
+				return True
+			return False
 
 		# Get the actual host (domain)
 		host = parsed.hostname

--- a/ghosthands/actions/domhand_fill.py
+++ b/ghosthands/actions/domhand_fill.py
@@ -3588,9 +3588,7 @@ async def _fill_toggle(page: Any, field: FormField, value: str, tag: str) -> boo
 
 
 def _get_profile_text() -> str | None:
-    text = os.environ.get("GH_USER_PROFILE_TEXT", "")
-    if text.strip():
-        return text.strip()
+    # Prefer file-based path (secure, avoids /proc/pid/environ exposure)
     path = os.environ.get("GH_USER_PROFILE_PATH", "")
     if path:
         try:
@@ -3601,11 +3599,30 @@ def _get_profile_text() -> str | None:
                 return p.read_text(encoding="utf-8").strip()
         except Exception as e:
             logger.warning(f"Failed to read profile from {path}: {e}")
+    # Fallback to env var for backwards compat (desktop bridge)
+    text = os.environ.get("GH_USER_PROFILE_TEXT", "")
+    if text.strip():
+        return text.strip()
     return None
 
 
 def _get_profile_data() -> dict[str, Any]:
     """Return structured applicant profile data when available."""
+    # Prefer file-based path (secure, avoids /proc/pid/environ exposure)
+    path = os.environ.get("GH_USER_PROFILE_PATH", "")
+    if path:
+        try:
+            import pathlib
+
+            p = pathlib.Path(path)
+            if p.is_file():
+                parsed = json.loads(p.read_text(encoding="utf-8"))
+                if isinstance(parsed, dict):
+                    return parsed
+        except Exception as e:
+            logger.warning(f"Failed to parse profile JSON from {path}: {e}")
+
+    # Fallback to env vars for backwards compat
     raw_json = os.environ.get("GH_USER_PROFILE_JSON", "")
     if raw_json.strip():
         try:
@@ -3623,18 +3640,5 @@ def _get_profile_data() -> dict[str, Any]:
                 return parsed
         except Exception:
             pass
-
-    path = os.environ.get("GH_USER_PROFILE_PATH", "")
-    if path:
-        try:
-            import pathlib
-
-            p = pathlib.Path(path)
-            if p.is_file():
-                parsed = json.loads(p.read_text(encoding="utf-8"))
-                if isinstance(parsed, dict):
-                    return parsed
-        except Exception as e:
-            logger.warning(f"Failed to parse profile JSON from {path}: {e}")
 
     return {}

--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -196,19 +196,19 @@ def _load_profile(args: argparse.Namespace) -> dict:
         except Exception:
             return _validate_profile(data)
 
-    # Environment variable fallback (for desktop bridge)
-    profile_text = os.environ.get("GH_USER_PROFILE_TEXT", "")
-    if profile_text:
-        return _validate_profile(json.loads(profile_text))
-
-    # File-based profile fallback
+    # File-based profile (preferred — avoids /proc/pid/environ exposure)
     profile_path = os.environ.get("GH_USER_PROFILE_PATH", "")
     if profile_path:
         p = Path(profile_path)
         if p.is_file():
             return _validate_profile(json.loads(p.read_text(encoding="utf-8")))
 
-    raise ValueError("Either --profile, --test-data, or GH_USER_PROFILE_TEXT env var is required")
+    # Environment variable fallback (for backwards compat with desktop bridge)
+    profile_text = os.environ.get("GH_USER_PROFILE_TEXT", "")
+    if profile_text:
+        return _validate_profile(json.loads(profile_text))
+
+    raise ValueError("Either --profile, --test-data, GH_USER_PROFILE_PATH, or GH_USER_PROFILE_TEXT env var is required")
 
 
 def _apply_runtime_env(


### PR DESCRIPTION
## Summary
- **P0**: Switch data: URI filter from blocklist → allowlist in security watchdog. Only allow known-safe MIME types (image/*, font/*, audio/*, video/*). Explicitly blocks image/svg+xml (can execute scripts). Previously missed SVG+XML, XHTML+XML, text/xml.
- **P1**: Reorder profile loading in domhand_fill.py and cli.py to prefer `GH_USER_PROFILE_PATH` (secure 0600 temp file) over `GH_USER_PROFILE_TEXT` (env var exposed via /proc/pid/environ).

## Test plan
- [ ] Verify data:image/png URIs still work (logo rendering)
- [ ] Verify data:image/svg+xml URIs are blocked
- [ ] Verify data:text/html URIs are blocked
- [ ] Verify data:application/javascript URIs are blocked
- [ ] Verify profile loads from GH_USER_PROFILE_PATH when both PATH and TEXT are set

🤖 Generated with [Claude Code](https://claude.com/claude-code)