### PR TITLE
fix(cli): prevent viewport override when connecting to Desktop-owned browser

### DIFF
--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -2020,9 +2020,13 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
 
     if cdp_url:
         # Desktop-owned browser: connect to existing browser via CDP URL.
-        # Do not launch a new browser; headless flag is irrelevant here.
+        # Do not launch a new browser; the browser is always headful (visible to user).
         # If GH_TARGET_ID is set, attach to that specific tab (shared-browser mode).
-        browser_profile = BrowserProfile(keep_alive=True, allowed_domains=allowed_domains)
+        # Explicit headless=False + no_viewport=True prevents detect_display_configuration()
+        # from incorrectly assuming headless mode (get_display_size() returns None in
+        # Electron-spawned subprocesses) and setting a 1920x1080 viewport override via CDP,
+        # which would cause pages to render wider than the physical Chrome window.
+        browser_profile = BrowserProfile(keep_alive=True, allowed_domains=allowed_domains, headless=False, no_viewport=True)
         browser = BrowserSession(browser_profile=browser_profile, cdp_url=cdp_url, target_id=cdp_target_id)
         if cdp_target_id:
             emit_status(f"Connecting to Desktop-owned browser via CDP (target: {cdp_target_id[:8]}...)", job_id=job_id)
@@ -2780,7 +2784,9 @@ async def run_agent_human(args: argparse.Namespace) -> None:
     desktop_owns_browser = cdp_url is not None
 
     if cdp_url:
-        browser_profile = BrowserProfile(keep_alive=True, allowed_domains=allowed_domains)
+        # Desktop-owned browser is always headful; bypass faulty display auto-detection
+        # (see primary CDP path above for full rationale).
+        browser_profile = BrowserProfile(keep_alive=True, allowed_domains=allowed_domains, headless=False, no_viewport=True)
         browser = BrowserSession(browser_profile=browser_profile, cdp_url=cdp_url)
         print(f"Connecting to Desktop-owned browser via CDP: {cdp_url}")
     else:


### PR DESCRIPTION
## Summary

- When Hand-X runs as a subprocess spawned by Electron, `get_display_size()` returns `None` (NSScreen fails without WindowServer access). This causes `detect_display_configuration()` to assume headless mode, setting `viewport=1920x1080` and sending `Emulation.setDeviceMetricsOverride` via CDP — making pages render wider than the physical Chrome window.
- Fix: explicitly pass `headless=False, no_viewport=True` when creating `BrowserProfile` for Desktop-owned browsers. Pages now render at the actual Chrome window size.
- Applied to both CDP paths: `run_agent_jsonl` (line 2029) and `run_agent_human` (line 2789).

## Root cause trace

1. `get_display_size()` → `NSScreen.mainScreen()` → returns `nil` in Electron subprocess → caught silently → returns `None`
2. `detect_display_configuration()` → `has_screen_available = False` → `self.headless = True` (wrong!)
3. Headless branch → `self.viewport = 1920x1080`, `self.no_viewport = False`
4. `on_TabCreatedEvent` → `Emulation.setDeviceMetricsOverride(1920, 1080)` → page thinks it's 1920px wide in a ~1360px window

## Test plan

- [ ] Queue a job in the Desktop app (`new_tabs` mode) — verify the log NO LONGER shows `Setting viewport to 1920x1080`
- [ ] Verify the job application page is centered in the Chrome window
- [ ] Verify scrolling works to the bottom of the page
- [ ] Verify Hand-X still fills out forms correctly (no regression)
- [ ] Verify standalone Hand-X CLI (no `GH_CDP_URL`) still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)