### PR TITLE
feat(cli): skip email-verification walls with explicit user notice

### DIFF
--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -1263,6 +1263,16 @@ _TERMINAL_BLOCKER_PATTERNS = (
     "stored credentials are invalid",
     "credential is invalid",
 )
+_VERIFICATION_SKIP_PATTERNS = (
+    "email verification",
+    "verification code",
+    "verification email",
+    "verify your account",
+    "verify your email",
+    "one-time code",
+    "one time passcode",
+)
+_OTP_RE = re.compile(r"\botp\b", re.IGNORECASE)
 _REQUIRED_FIELD_RE = re.compile(r"required field ['\"](?P<field>[^'\"]+)['\"]", re.IGNORECASE)
 _SECTION_RE = re.compile(r"on the ['\"](?P<section>[^'\"]+)['\"] page", re.IGNORECASE)
 
@@ -1357,6 +1367,16 @@ def _looks_like_answer_needed_blocker(text: str | None) -> bool:
 def _looks_like_terminal_blocker(text: str | None) -> bool:
     lowered = (text or "").lower()
     return bool(lowered) and any(pattern in lowered for pattern in _TERMINAL_BLOCKER_PATTERNS)
+
+
+def _is_verification_code_blocker(text: str | None) -> bool:
+    """True when a blocker is an email/SMS verification wall — unsupported, skip with notice."""
+    if not text:
+        return False
+    lowered = text.lower()
+    if any(pattern in lowered for pattern in _VERIFICATION_SKIP_PATTERNS):
+        return True
+    return _OTP_RE.search(lowered) is not None
 
 
 def _extract_application_state_json(summary: str) -> dict[str, Any]:
@@ -2549,10 +2569,18 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
             if exit_code is not None:
                 sys.exit(exit_code)
         else:
+            termination_status = "agent_incomplete"
+            terminal_message = blocker or final_result or "Agent did not complete successfully"
+            if _is_verification_code_blocker(blocker):
+                termination_status = "verification_code_required"
+                terminal_message = (
+                    "This application requires an email verification code — skipped for now. "
+                    "Email-verification applications are not yet supported."
+                )
             jt.emit_run_terminal(
-                termination_status="agent_incomplete",
+                termination_status=termination_status,
                 success=False,
-                message=blocker or final_result or "Agent did not complete successfully",
+                message=terminal_message,
                 fields_filled=filled_count,
                 fields_failed=failed_count,
                 job_id=job_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ghosthands"
-version = "0.2.0"
+version = "0.2.1"
 description = "GhostHands v2 — Job application automation agent built on browser-use"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/test_verification_skip.py
+++ b/tests/unit/test_verification_skip.py
@@ -1,0 +1,49 @@
+"""Unit tests for verification-code blocker classification.
+
+When an application hits an email/SMS verification wall, the run must
+terminate with status "verification_code_required" and a user-facing
+"skipped for now" message instead of the generic "agent_incomplete".
+
+All tests are offline (no browser, no database, no API calls).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ghosthands.cli import _is_verification_code_blocker
+
+
+class TestIsVerificationCodeBlocker:
+    @pytest.mark.parametrize(
+        "blocker",
+        [
+            # Exact phrasing the agent prompt rule instructs (prompts.py _verification_rule)
+            "blocker: email verification required — user must verify email then retry",
+            "blocker: the page asks for a verification code sent to the inbox",
+            "blocker: verification email sent, cannot proceed",
+            "blocker: please verify your account before continuing",
+            "blocker: verify your email address to continue",
+            "blocker: a one-time code was sent to the user's email",
+            "blocker: one time passcode required",
+            "blocker: OTP required to sign in",
+        ],
+    )
+    def test_matches_verification_walls(self, blocker: str) -> None:
+        assert _is_verification_code_blocker(blocker) is True
+
+    @pytest.mark.parametrize(
+        "blocker",
+        [
+            None,
+            "",
+            "blocker: sign-in failed — invalid password",
+            "blocker: captcha detected",
+            "blocker: position closed",
+            "blocker: required field 'Phone' could not be filled",
+            # 'otp' must match as a whole word only
+            "blocker: hotpot restaurant application form is broken",
+        ],
+    )
+    def test_ignores_non_verification_blockers(self, blocker: str | None) -> None:
+        assert _is_verification_code_blocker(blocker) is False


### PR DESCRIPTION
## Summary
- Blockers caused by email/SMS verification codes now terminate with status `verification_code_required` and user-facing copy: "This application requires an email verification code — skipped for now. Email-verification applications are not yet supported."
- Previously these surfaced as generic `agent_incomplete` with raw blocker text.
- Detection reuses the blocker text the shared verification prompt rule already makes the agent emit (`blocker: email verification required — …`); `otp` matched word-boundary only. No agent-loop, platform, or Workday-preface changes.
- Message rides existing plumbing: JSONL `done` → Desktop notification → VALET task error + application report.

## Tests
- `tests/unit/test_verification_skip.py`: 15 cases (verification walls match, sign-in failures/captcha/hotpot don't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)