### PR TITLE
feat(cli): add VALET review-only terminal runtime

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -29,16 +29,15 @@ jobs:
           - os: macos-14        # Apple Silicon (M1+)
             name: darwin-arm64
             runner_arch: arm64
-          # TODO: re-enable when needed
-          # - os: macos-15        # x64 Python via Rosetta on Apple Silicon
-          #   name: darwin-x64
-          #   runner_arch: x64
-          # - os: ubuntu-22.04    # Linux x64
-          #   name: linux-x64
-          #   runner_arch: x64
-          # - os: windows-latest  # Windows x64
-          #   name: win-x64
-          #   runner_arch: x64
+          - os: macos-15-intel  # Intel macOS
+            name: darwin-x64
+            runner_arch: x64
+          - os: ubuntu-22.04    # Linux x64
+            name: linux-x64
+            runner_arch: x64
+          - os: windows-latest  # Windows x64
+            name: win-x64
+            runner_arch: x64
 
     runs-on: ${{ matrix.os }}
     name: Build (${{ matrix.name }})
@@ -124,7 +123,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     needs: build
-    if: always() && !cancelled() && startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && needs.build.result == 'success'
     runs-on: ubuntu-latest
     name: Create Release
 

--- a/ghosthands/__init__.py
+++ b/ghosthands/__init__.py
@@ -1,3 +1,3 @@
 """GhostHands v2 — Job application automation agent built on browser-use."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -44,7 +44,7 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import structlog
 
@@ -58,6 +58,9 @@ from ghosthands.bridge.protocol import (
     wait_for_review_command,
 )
 
+if TYPE_CHECKING:
+    from browser_use import Agent
+
 # Backward-compatible alias retained for older internal imports/tests.
 _camel_to_snake_profile = camel_to_snake_profile
 
@@ -67,7 +70,7 @@ os.environ["PYTHONUNBUFFERED"] = "1"
 # Suppress browser-use's own logging setup so we control stderr exclusively
 os.environ["BROWSER_USE_SETUP_LOGGING"] = "false"
 
-from ghosthands.agent.hooks import (
+from ghosthands.agent.hooks import (  # noqa: E402
     consume_blocked_final_submit,
     install_final_submit_guard,
     install_same_tab_guard,
@@ -300,9 +303,7 @@ async def _inspect_workday_runtime_state(browser_session, page) -> dict[str, Any
     """Inspect lightweight Workday page state for deterministic auth handling."""
     derived_from_browser_text: dict[str, Any] = {}
     with contextlib.suppress(Exception):
-        derived_from_browser_text = _derive_workday_state_from_browser_text(
-            await browser_session.get_state_as_text()
-        )
+        derived_from_browser_text = _derive_workday_state_from_browser_text(await browser_session.get_state_as_text())
     try:
         state = await page.evaluate(
             r"""() => {
@@ -624,6 +625,10 @@ def parse_args() -> argparse.Namespace:
     argv = sys.argv[1:]
     if argv and argv[0] == "apply":
         argv = argv[1:]
+    if argv and argv[0] in {"tui", "terminal"}:
+        argv = ["--output-format", "tui", *argv[1:]]
+    elif not argv and sys.stdin.isatty() and sys.stdout.isatty():
+        argv = ["--output-format", "tui"]
 
     parser = argparse.ArgumentParser(
         prog="hand-x",
@@ -637,7 +642,7 @@ def parse_args() -> argparse.Namespace:
     )
 
     # Required
-    parser.add_argument("--job-url", required=True, help="Job posting URL to apply to")
+    parser.add_argument("--job-url", default=None, help="Job posting URL to apply to")
 
     # Profile source (one of these is required)
     parser.add_argument("--profile", default=None, help="Applicant profile as JSON string or @filepath")
@@ -665,9 +670,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--headless", action="store_true", help="Run browser headless")
     parser.add_argument(
         "--output-format",
-        choices=["jsonl", "human"],
+        choices=["jsonl", "human", "tui"],
         default="jsonl",
-        help="Output format: jsonl for IPC, human for terminal (default: jsonl)",
+        help="Output format: jsonl for IPC, human for raw terminal logs, tui for interactive terminal UX",
     )
 
     # VALET proxy
@@ -692,8 +697,17 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Connect to an existing browser via CDP URL instead of launching a new one (Desktop-owned browser mode)",
     )
+    parser.add_argument(
+        "--engine",
+        choices=["auto", "chromium", "firefox"],
+        default="auto",
+        help="Reserved browser engine selector for the terminal app",
+    )
 
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.output_format != "tui" and not args.job_url:
+        parser.error("the following arguments are required: --job-url")
+    return args
 
 
 # ── Logging setup ─────────────────────────────────────────────────────
@@ -702,7 +716,7 @@ def parse_args() -> argparse.Namespace:
 class _CompactFormatter(logging.Formatter):
     """Shorten noisy logger names while keeping everything else intact."""
 
-    _REWRITES = {
+    _REWRITES: ClassVar[dict[str, str]] = {
         "Agent": "Agent",
         "BrowserSession": "Session",
         "tools": "tools",
@@ -863,7 +877,7 @@ def _load_desktop_overlay_fields() -> dict[str, Any] | None:
         "learnedInteractionRecipes",
         "learned_interaction_recipes",
     ):
-        if key in data and data[key]:
+        if data.get(key):
             overlay[key] = data[key]
     return overlay if overlay else None
 
@@ -950,7 +964,7 @@ def _load_runtime_settings():
     """Load settings after CLI-provided environment overrides are applied."""
     from ghosthands.config.settings import Settings
 
-    return Settings()
+    return Settings()  # pyright: ignore[reportCallIssue]
 
 
 def _resolve_sensitive_data(
@@ -1399,7 +1413,7 @@ async def _collect_open_question_issues_from_browser(browser: Any) -> list[_Open
         from ghosthands.actions.domhand_assess_state import domhand_assess_state
         from ghosthands.actions.views import DomHandAssessStateParams
 
-        result = await domhand_assess_state(DomHandAssessStateParams(), browser)
+        result = await domhand_assess_state(DomHandAssessStateParams(target_section=None), browser)
         summary = result.extracted_content or ""
         payload: dict[str, Any] = {}
         meta = getattr(result, "metadata", None) or {}
@@ -1481,9 +1495,9 @@ async def _auto_answer_open_question_issues(
         _default_screening_answer,
         _find_best_profile_answer,
         _known_profile_value,
-        _semantic_profile_value_for_field,
         _normalize_match_label,
         _parse_profile_evidence,
+        _semantic_profile_value_for_field,
     )
     from ghosthands.actions.views import FormField
     from ghosthands.runtime_learning import confirm_learned_question_alias
@@ -1561,8 +1575,8 @@ async def _infer_open_question_answers_with_domhand(
     if not isinstance(profile, dict):
         return [], issues
 
-    from ghosthands.actions.domhand_fill import infer_answers_for_fields
     from ghosthands.actions.views import FormField
+    from ghosthands.dom.fill_llm_answers import infer_answers_for_fields
 
     synthetic_fields: list[FormField] = []
     issue_by_field_id: dict[str, _OpenQuestionIssue] = {}
@@ -1836,11 +1850,7 @@ def _jsonl_done_signals_incomplete_outcome(final_result: str, history: Any) -> b
                 f"{getattr(cs, 'evaluation_previous_goal', '')} "
                 f"{getattr(cs, 'next_goal', '')}"
             ).lower()
-            if (
-                "step limit" in blob
-                or "maximum steps" in blob
-                or "terminated due to step limit" in blob
-            ):
+            if "step limit" in blob or "maximum steps" in blob or "terminated due to step limit" in blob:
                 return True
     except Exception:
         pass
@@ -2046,7 +2056,9 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
         # from incorrectly assuming headless mode (get_display_size() returns None in
         # Electron-spawned subprocesses) and setting a 1920x1080 viewport override via CDP,
         # which would cause pages to render wider than the physical Chrome window.
-        browser_profile = BrowserProfile(keep_alive=True, allowed_domains=allowed_domains, headless=False, no_viewport=True)
+        browser_profile = BrowserProfile(
+            keep_alive=True, allowed_domains=allowed_domains, headless=False, no_viewport=True
+        )
         browser = BrowserSession(browser_profile=browser_profile, cdp_url=cdp_url, target_id=cdp_target_id)
         if cdp_target_id:
             emit_status(f"Connecting to Desktop-owned browser via CDP (target: {cdp_target_id[:8]}...)", job_id=job_id)
@@ -2133,7 +2145,17 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
                 from ghosthands.actions.views import DomHandFillParams
 
                 _emit_phase_if_changed("Auto-filling form fields")
-                result = await _domhand_fill(DomHandFillParams(), ag.browser_session)
+                result = await _domhand_fill(
+                    DomHandFillParams(
+                        target_section=None,
+                        heading_boundary=None,
+                        focus_fields=None,
+                        entry_data=None,
+                        use_auth_credentials=False,
+                        strict_scope=False,
+                    ),
+                    ag.browser_session,
+                )
                 if result and not result.error:
                     ag.state.last_result = [result]
                     logger.warning(
@@ -2258,7 +2280,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
                             domain=hostname or None,
                             email=app_settings.email,
                             password=app_settings.password,
-                            credential_status=marker_status,
+                            credential_status=marker_status or "active",
                             note=marker_note,
                             evidence=marker_evidence,
                             url=url,
@@ -2281,7 +2303,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
         )
         try:
             await asyncio.wait_for(browser.start(), timeout=60)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.error("startup.browser_launch_timeout", timeout_seconds=60)
             emit_error("Browser failed to start within 60 seconds", fatal=True, job_id=job_id)
             jt.emit_run_terminal(
@@ -2349,7 +2371,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
                 browser_session=browser,
                 tools=tools,
                 extend_system_message=system_ext or None,
-                sensitive_data=sensitive_data,
+                sensitive_data=cast("dict[str, str | dict[str, str]] | None", sensitive_data),
                 available_file_paths=available_files or None,
                 use_vision="auto",
                 max_actions_per_step=app_settings.agent_max_actions_per_step,
@@ -2426,9 +2448,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
 
         filled_count, failed_count = get_field_counts()
         filled_field_records = get_filled_field_records()
-        best_effort_guess_count, best_effort_guess_fields = _extract_best_effort_guess_summary(
-            filled_field_records
-        )
+        best_effort_guess_count, best_effort_guess_fields = _extract_best_effort_guess_summary(filled_field_records)
 
         if cancelled:
             from ghosthands.runtime_learning import export_runtime_learning_payload
@@ -2438,9 +2458,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
                 logger.info(
                     "cli.runtime_learning_export",
                     extra={
-                        "learned_question_aliases": len(
-                            runtime_learning_payload.get("learned_question_aliases") or []
-                        ),
+                        "learned_question_aliases": len(runtime_learning_payload.get("learned_question_aliases") or []),
                         "learned_interaction_recipes": len(
                             runtime_learning_payload.get("learned_interaction_recipes") or []
                         ),
@@ -2515,9 +2533,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
             logger.info(
                 "cli.runtime_learning_export",
                 extra={
-                    "learned_question_aliases": len(
-                        runtime_learning_payload.get("learned_question_aliases") or []
-                    ),
+                    "learned_question_aliases": len(runtime_learning_payload.get("learned_question_aliases") or []),
                     "learned_interaction_recipes": len(
                         runtime_learning_payload.get("learned_interaction_recipes") or []
                     ),
@@ -2814,7 +2830,9 @@ async def run_agent_human(args: argparse.Namespace) -> None:
     if cdp_url:
         # Desktop-owned browser is always headful; bypass faulty display auto-detection
         # (see primary CDP path above for full rationale).
-        browser_profile = BrowserProfile(keep_alive=True, allowed_domains=allowed_domains, headless=False, no_viewport=True)
+        browser_profile = BrowserProfile(
+            keep_alive=True, allowed_domains=allowed_domains, headless=False, no_viewport=True
+        )
         browser = BrowserSession(browser_profile=browser_profile, cdp_url=cdp_url)
         print(f"Connecting to Desktop-owned browser via CDP: {cdp_url}")
     else:
@@ -2902,7 +2920,7 @@ async def run_agent_human(args: argparse.Namespace) -> None:
         browser_session=browser,
         tools=tools,
         extend_system_message=system_ext or None,
-        sensitive_data=sensitive_data,
+        sensitive_data=cast("dict[str, str | dict[str, str]] | None", sensitive_data),
         available_file_paths=available_files or None,
         use_vision="auto",
         max_actions_per_step=app_settings.agent_max_actions_per_step,
@@ -2958,10 +2976,17 @@ async def run_agent_human(args: argparse.Namespace) -> None:
     except Exception as e:
         print(f"\n  [ERROR] Cost summary failed: {e}", file=sys.stderr)
         sys.stderr.flush()
-        cost_summary = {"total_tracked_cost_usd": 0, "browser_use_cost_usd": 0,
-                        "domhand_cost_usd": 0, "stagehand_calls": 0, "stagehand_used": False,
-                        "total_tracked_prompt_tokens": 0, "total_tracked_completion_tokens": 0,
-                        "untracked_cost_possible": True, "untracked_reasons": [str(e)]}
+        cost_summary = {
+            "total_tracked_cost_usd": 0,
+            "browser_use_cost_usd": 0,
+            "domhand_cost_usd": 0,
+            "stagehand_calls": 0,
+            "stagehand_used": False,
+            "total_tracked_prompt_tokens": 0,
+            "total_tracked_completion_tokens": 0,
+            "untracked_cost_possible": True,
+            "untracked_reasons": [str(e)],
+        }
     try:
         _print_human_result_summary(history, cost_summary)
     except Exception as e:
@@ -2995,8 +3020,9 @@ def main() -> None:
     args = parse_args()
 
     is_jsonl = args.output_format == "jsonl"
+    is_tui = args.output_format == "tui"
 
-    if not is_jsonl:
+    if not is_jsonl and not is_tui:
         signal.signal(signal.SIGTERM, _handle_sigterm)
 
     # Install stdout guard BEFORE any library imports in JSONL mode.
@@ -3010,7 +3036,12 @@ def main() -> None:
 
     _setup_logging()
 
-    runner = run_agent_jsonl if is_jsonl else run_agent_human
+    if is_tui:
+        from ghosthands.tui import run_tui
+
+        runner = run_tui
+    else:
+        runner = run_agent_jsonl if is_jsonl else run_agent_human
 
     try:
         asyncio.run(runner(args))

--- a/ghosthands/tui.py
+++ b/ghosthands/tui.py
@@ -1,0 +1,581 @@
+"""Rich terminal UI for running Hand-X without the Electron desktop app."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import os
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from rich.console import Console, Group
+from rich.live import Live
+from rich.panel import Panel
+from rich.prompt import Confirm, Prompt
+from rich.table import Table
+from rich.text import Text
+
+
+class TuiEvent(BaseModel):
+    """Validated JSONL event from the Hand-X engine process."""
+
+    model_config = ConfigDict(extra="allow")
+
+    event: str
+    timestamp: int | float | None = None
+
+    @property
+    def data(self) -> dict[str, Any]:
+        return self.model_extra or {}
+
+
+@dataclass
+class TuiRunState:
+    """Small render state derived from engine JSONL events."""
+
+    job_url: str = ""
+    phase: str = "Setup"
+    status: str = "Waiting for engine"
+    step: int | None = None
+    max_steps: int | None = None
+    cost_usd: float = 0.0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    fields_filled: int = 0
+    fields_failed: int = 0
+    cdp_url: str = ""
+    page_url: str = ""
+    user_id: str = ""
+    job_id: str = ""
+    lease_id: str = ""
+    sync_status: str = "Local run"
+    awaiting_review: bool = False
+    done: bool = False
+    success: bool | None = None
+    message: str = ""
+    process_returncode: int | None = None
+    logs: list[tuple[str, str]] = field(default_factory=list)
+
+    def add_log(self, kind: str, message: str) -> None:
+        message = " ".join(str(message or "").split())
+        if not message:
+            return
+        if len(message) > 180:
+            message = f"{message[:177]}..."
+        self.logs.append((kind, message))
+        del self.logs[:-12]
+
+    def apply_event(self, event: TuiEvent) -> None:
+        kind = event.event
+        data = event.data
+
+        if kind == "handshake":
+            self.status = "Engine connected"
+            version = data.get("protocol_version")
+            self.add_log("engine", f"Protocol v{version}" if version else "Protocol ready")
+            return
+
+        if kind == "phase":
+            self.phase = str(data.get("phase") or self.phase)
+            detail = data.get("detail")
+            self.status = str(detail or self.phase)
+            self.add_log("phase", self.status)
+            return
+
+        if kind == "status":
+            self.status = str(data.get("message") or self.status)
+            self.step = _maybe_int(data.get("step"), self.step)
+            self.max_steps = _maybe_int(data.get("maxSteps"), self.max_steps)
+            self.add_log("status", self.status)
+            return
+
+        if kind == "progress":
+            self.step = _maybe_int(data.get("step"), self.step)
+            self.max_steps = _maybe_int(data.get("maxSteps"), self.max_steps)
+            description = str(data.get("description") or "Progress updated")
+            self.status = description
+            self.add_log("progress", description)
+            return
+
+        if kind == "field_filled":
+            self.fields_filled += 1
+            field_name = str(data.get("field") or "field")
+            value = _safe_value(field_name, data.get("value"))
+            self.add_log("filled", f"{field_name}: {value}")
+            return
+
+        if kind == "field_failed":
+            self.fields_failed += 1
+            field_name = str(data.get("field") or "field")
+            reason = str(data.get("reason") or "failed")
+            self.add_log("failed", f"{field_name}: {reason}")
+            return
+
+        if kind == "cost":
+            self.cost_usd = float(data.get("total_usd") or 0.0)
+            self.prompt_tokens = int(data.get("prompt_tokens") or 0)
+            self.completion_tokens = int(data.get("completion_tokens") or 0)
+            return
+
+        if kind == "browser_ready":
+            self.cdp_url = str(data.get("cdpUrl") or "")
+            self.status = "Browser ready"
+            self.add_log("browser", "Browser ready for automation")
+            return
+
+        if kind == "account_created":
+            platform = str(data.get("platform") or "platform")
+            email = str(data.get("email") or "account")
+            status = str(data.get("credentialStatus") or "created")
+            self.add_log("account", f"{platform}: {email} ({status})")
+            return
+
+        if kind == "awaiting_review":
+            self.awaiting_review = True
+            self.phase = "Review"
+            self.status = str(data.get("message") or "Review the application in the browser")
+            self.cdp_url = str(data.get("cdpUrl") or self.cdp_url)
+            self.page_url = str(data.get("pageUrl") or self.page_url)
+            self.add_log("review", self.status)
+            return
+
+        if kind == "error":
+            self.status = str(data.get("message") or "Engine error")
+            self.add_log("error", self.status)
+            return
+
+        if kind == "done":
+            self.done = True
+            self.success = bool(data.get("success"))
+            self.message = str(data.get("message") or "")
+            self.status = self.message or ("Done" if self.success else "Finished")
+            self.fields_filled = _maybe_int(data.get("fields_filled"), self.fields_filled) or 0
+            self.fields_failed = _maybe_int(data.get("fields_failed"), self.fields_failed) or 0
+            self.add_log("done", self.status)
+            return
+
+        if kind == "lease_acquired":
+            self.lease_id = str(data.get("leaseId") or self.lease_id)
+            self.job_id = str(data.get("jobId") or self.job_id)
+            self.sync_status = "VALET sync active"
+            self.add_log("sync", f"Lease acquired: {self.lease_id or 'unknown'}")
+            return
+
+        if kind == "lease_heartbeat":
+            self.lease_id = str(data.get("leaseId") or self.lease_id)
+            self.sync_status = "VALET heartbeat"
+            return
+
+        if kind == "lease_released":
+            self.lease_id = str(data.get("leaseId") or self.lease_id)
+            reason = str(data.get("reason") or "completed")
+            self.sync_status = f"VALET released ({reason})"
+            self.add_log("sync", self.sync_status)
+            return
+
+        self.add_log(kind, kind)
+
+
+def parse_jsonl_event(line: str) -> TuiEvent | None:
+    """Parse one engine JSONL line into a validated event."""
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        return TuiEvent.model_validate(payload)
+    except ValueError:
+        return None
+
+
+def build_engine_argv(args: argparse.Namespace, executable: Sequence[str] | None = None) -> list[str]:
+    """Build the JSONL child-process argv for the current TUI request."""
+    if executable is not None:
+        argv = list(executable)
+    elif getattr(sys, "frozen", False):
+        argv = [sys.executable]
+    else:
+        argv = [sys.executable, "-m", "ghosthands.cli"]
+
+    def add_option(name: str, value: Any) -> None:
+        if value is None or value == "":
+            return
+        argv.extend([name, str(value)])
+
+    add_option("--job-url", args.job_url)
+    add_option("--profile", args.profile)
+    add_option("--test-data", args.test_data)
+    add_option("--user-id", args.user_id)
+    add_option("--resume-id", args.resume_id)
+    add_option("--resume", args.resume)
+    add_option("--job-id", args.job_id)
+    add_option("--lease-id", args.lease_id)
+    add_option("--model", args.model)
+    add_option("--max-steps", args.max_steps)
+    add_option("--max-budget", args.max_budget)
+    add_option("--submit-intent", args.submit_intent)
+    add_option("--proxy-url", args.proxy_url)
+    add_option("--runtime-grant", args.runtime_grant)
+    add_option("--allowed-domains", args.allowed_domains)
+    add_option("--browsers-path", args.browsers_path)
+    add_option("--cdp-url", args.cdp_url)
+    add_option("--engine", getattr(args, "engine", None))
+    if args.headless:
+        argv.append("--headless")
+    argv.extend(["--output-format", "jsonl"])
+    return argv
+
+
+async def run_tui(args: argparse.Namespace) -> None:
+    """Prompt for any missing inputs, run the JSONL engine, and render progress."""
+    console = Console()
+    args = _collect_tui_args(args, console)
+    state = TuiRunState(
+        job_url=args.job_url,
+        max_steps=args.max_steps,
+        user_id=str(args.user_id or ""),
+        job_id=str(args.job_id or ""),
+        lease_id=str(args.lease_id or ""),
+        sync_status=_sync_status_label(args),
+    )
+    argv = build_engine_argv(args)
+    env = {**os.environ, "PYTHONUNBUFFERED": "1"}
+
+    console.print(_intro_panel(args))
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+
+    stdout_task = asyncio.create_task(_read_stdout(proc, state))
+    stderr_task = asyncio.create_task(_read_stderr(proc, state))
+    review_command_sent = False
+
+    try:
+        while proc.returncode is None:
+            with Live(_render_state(state), console=console, refresh_per_second=4) as live:
+                while proc.returncode is None and not (state.awaiting_review and not review_command_sent):
+                    live.update(_render_state(state))
+                    await asyncio.sleep(0.25)
+
+            if state.awaiting_review and not review_command_sent:
+                await _handle_review_prompt(proc, state, console)
+                review_command_sent = True
+                state.awaiting_review = False
+                state.status = "Review command sent; waiting for engine shutdown"
+                continue
+
+        state.process_returncode = await proc.wait()
+        await _finish_reader(stdout_task)
+        await _finish_reader(stderr_task)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        await _cancel_engine(proc, state, console)
+        raise
+    finally:
+        for task in (stdout_task, stderr_task):
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+    console.print(_final_panel(state))
+    if state.process_returncode not in (0, None) and not state.success:
+        raise SystemExit(state.process_returncode)
+
+
+def _collect_tui_args(args: argparse.Namespace, console: Console) -> argparse.Namespace:
+    """Fill missing CLI args from terminal prompts."""
+    values = vars(args).copy()
+    missing_core = not values.get("job_url")
+    has_profile_source = any(values.get(key) for key in ("profile", "test_data", "user_id")) or bool(
+        os.getenv("GH_USER_PROFILE_PATH") or os.getenv("GH_USER_PROFILE_TEXT")
+    )
+
+    if (missing_core or not has_profile_source) and not sys.stdin.isatty():
+        raise SystemExit("TUI mode needs an interactive terminal when job/profile inputs are missing.")
+
+    if not sys.stdin.isatty():
+        values["submit_intent"] = values.get("submit_intent") or "review"
+        values["output_format"] = "tui"
+        return argparse.Namespace(**values)
+
+    if not values.get("job_url"):
+        values["job_url"] = Prompt.ask("Job URL").strip()
+    if not values.get("job_url"):
+        raise SystemExit("Job URL is required.")
+
+    if not has_profile_source:
+        source = Prompt.ask(
+            "Profile source",
+            choices=["profile", "test-data", "user-id", "env"],
+            default="profile",
+        )
+        if source == "profile":
+            values["profile"] = Prompt.ask("Profile JSON or @file").strip()
+        elif source == "test-data":
+            values["test_data"] = Prompt.ask("Test data JSON path").strip()
+        elif source == "user-id":
+            values["user_id"] = Prompt.ask("User ID").strip()
+            resume_id = Prompt.ask("Resume ID (optional)", default="").strip()
+            values["resume_id"] = resume_id or None
+
+    if not values.get("resume"):
+        resume = Prompt.ask("Resume PDF path (optional)", default="").strip()
+        values["resume"] = resume or None
+
+    if not values.get("model"):
+        model = Prompt.ask("Model override (optional)", default="").strip()
+        values["model"] = model or None
+
+    values["max_steps"] = int(Prompt.ask("Max steps", default=str(values.get("max_steps") or 50)))
+    values["max_budget"] = float(Prompt.ask("Max budget USD", default=str(values.get("max_budget") or 0.5)))
+    values["headless"] = Confirm.ask("Run browser headless?", default=bool(values.get("headless")))
+
+    if not values.get("submit_intent"):
+        values["submit_intent"] = Prompt.ask("Final submit mode", choices=["review", "submit"], default="review")
+
+    _validate_path(values.get("resume"), "Resume")
+    if values.get("profile") and str(values["profile"]).startswith("@"):
+        _validate_path(str(values["profile"])[1:], "Profile")
+    _validate_path(values.get("test_data"), "Test data")
+
+    values["resume"] = _normalize_path(values.get("resume"))
+    values["test_data"] = _normalize_path(values.get("test_data"))
+    if values.get("profile") and str(values["profile"]).startswith("@"):
+        values["profile"] = f"@{_normalize_path(str(values['profile'])[1:])}"
+
+    values["output_format"] = "tui"
+    return argparse.Namespace(**values)
+
+
+def _intro_panel(args: argparse.Namespace) -> Panel:
+    table = Table.grid(padding=(0, 2))
+    table.add_column(style="bold")
+    table.add_column()
+    table.add_row("Job", str(args.job_url))
+    table.add_row("Profile", _profile_source_label(args))
+    table.add_row("Resume", str(args.resume or "none"))
+    table.add_row("Mode", str(args.submit_intent or "review"))
+    table.add_row("Browser", "headless" if args.headless else "visible")
+    table.add_row("Sync", _sync_source_label(args))
+    return Panel(table, title="Hand-X Terminal", border_style="cyan")
+
+
+def _render_state(state: TuiRunState) -> Group:
+    summary = Table.grid(expand=True)
+    summary.add_column(ratio=1)
+    summary.add_column(ratio=1)
+    summary.add_column(ratio=1)
+    summary.add_row(
+        _metric("Phase", state.phase),
+        _metric("Progress", _progress_label(state)),
+        _metric("Cost", f"${state.cost_usd:.4f}"),
+    )
+    summary.add_row(
+        _metric("Fields", f"{state.fields_filled} filled / {state.fields_failed} failed"),
+        _metric("Tokens", f"{state.prompt_tokens} in / {state.completion_tokens} out"),
+        _metric("Browser", "ready" if state.cdp_url else "starting"),
+    )
+    summary.add_row(
+        _metric("Sync", state.sync_status),
+        _metric("Job", state.job_id or "local"),
+        _metric("Lease", state.lease_id or "-"),
+    )
+
+    log_table = Table(expand=True, show_header=True, header_style="bold cyan")
+    log_table.add_column("Type", no_wrap=True, width=10)
+    log_table.add_column("Latest activity")
+    for kind, message in state.logs[-12:]:
+        log_table.add_row(kind, Text(message))
+    if not state.logs:
+        log_table.add_row("setup", "Waiting for engine output")
+
+    status = Text(state.status or "", style="bold")
+    return Group(
+        Panel(summary, title="Run", border_style="cyan"),
+        Panel(status, title="Status", border_style="green" if not state.done else "cyan"),
+        Panel(log_table, title="Events", border_style="blue"),
+    )
+
+
+async def _read_stdout(proc: asyncio.subprocess.Process, state: TuiRunState) -> None:
+    if proc.stdout is None:
+        return
+    async for raw in proc.stdout:
+        line = raw.decode("utf-8", errors="replace").strip()
+        if not line:
+            continue
+        event = parse_jsonl_event(line)
+        if event is None:
+            state.add_log("stdout", line)
+            continue
+        state.apply_event(event)
+
+
+async def _read_stderr(proc: asyncio.subprocess.Process, state: TuiRunState) -> None:
+    if proc.stderr is None:
+        return
+    async for raw in proc.stderr:
+        line = raw.decode("utf-8", errors="replace").strip()
+        if line:
+            state.add_log("log", line)
+
+
+async def _handle_review_prompt(
+    proc: asyncio.subprocess.Process,
+    state: TuiRunState,
+    console: Console,
+) -> None:
+    console.print(_review_panel(state))
+    complete = Confirm.ask("Mark review complete and close the browser?", default=False)
+    command = {"type": "complete_review"} if complete else {"type": "cancel_job"}
+    await _send_command(proc, command)
+
+
+async def _send_command(proc: asyncio.subprocess.Process, command: dict[str, Any]) -> None:
+    if proc.stdin is None:
+        return
+    proc.stdin.write((json.dumps(command, separators=(",", ":")) + "\n").encode("utf-8"))
+    await proc.stdin.drain()
+
+
+async def _cancel_engine(proc: asyncio.subprocess.Process, state: TuiRunState, console: Console) -> None:
+    state.status = "Cancelling"
+    console.print("\nCancelling Hand-X...")
+    with contextlib.suppress(Exception):
+        await _send_command(proc, {"type": "cancel_job"})
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=10)
+    except TimeoutError:
+        proc.terminate()
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(proc.wait(), timeout=5)
+
+
+async def _finish_reader(task: asyncio.Task[None]) -> None:
+    if task.done():
+        await task
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+def _review_panel(state: TuiRunState) -> Panel:
+    table = Table.grid(padding=(0, 2))
+    table.add_column(style="bold")
+    table.add_column()
+    table.add_row("Status", state.status)
+    if state.page_url:
+        table.add_row("Page", state.page_url)
+    if state.cdp_url:
+        table.add_row("CDP", state.cdp_url)
+    table.add_row("Next", "Review the visible browser window before confirming.")
+    return Panel(table, title="Review Required", border_style="yellow")
+
+
+def _final_panel(state: TuiRunState) -> Panel:
+    ok = state.success is True
+    title = "Complete" if ok else "Stopped"
+    style = "green" if ok else "red"
+    table = Table.grid(padding=(0, 2))
+    table.add_column(style="bold")
+    table.add_column()
+    table.add_row("Result", state.message or state.status)
+    table.add_row("Fields", f"{state.fields_filled} filled / {state.fields_failed} failed")
+    table.add_row("Cost", f"${state.cost_usd:.4f}")
+    if state.process_returncode is not None:
+        table.add_row("Exit", str(state.process_returncode))
+    return Panel(table, title=title, border_style=style)
+
+
+def _metric(label: str, value: str) -> Panel:
+    body = Text(str(value), style="bold")
+    body.append(f"\n{label}", style="dim")
+    return Panel(body, padding=(0, 1))
+
+
+def _progress_label(state: TuiRunState) -> str:
+    if state.step is None:
+        return f"0/{state.max_steps}" if state.max_steps else "-"
+    if state.max_steps:
+        return f"{state.step}/{state.max_steps}"
+    return str(state.step)
+
+
+def _safe_value(field_name: str, value: Any) -> str:
+    name = str(field_name or "").lower()
+    if any(token in name for token in ("password", "secret", "token", "credential")):
+        return "[redacted]"
+    text = " ".join(str(value or "").split())
+    if not text:
+        return "(set)"
+    if len(text) > 80:
+        return f"{text[:77]}..."
+    return text
+
+
+def _maybe_int(value: Any, default: int | None = None) -> int | None:
+    if value is None or value == "":
+        return default
+    with contextlib.suppress(TypeError, ValueError):
+        return int(value)
+    return default
+
+
+def _profile_source_label(args: argparse.Namespace) -> str:
+    if args.profile:
+        return str(args.profile)
+    if args.test_data:
+        return str(args.test_data)
+    if args.user_id:
+        return f"user-id:{args.user_id}"
+    if os.getenv("GH_USER_PROFILE_PATH"):
+        return f"env:{os.getenv('GH_USER_PROFILE_PATH')}"
+    if os.getenv("GH_USER_PROFILE_TEXT"):
+        return "env:GH_USER_PROFILE_TEXT"
+    return "none"
+
+
+def _sync_status_label(args: argparse.Namespace) -> str:
+    if args.job_id or args.lease_id or args.user_id or args.proxy_url:
+        return "VALET sync pending"
+    return "Local run"
+
+
+def _sync_source_label(args: argparse.Namespace) -> str:
+    parts = []
+    if args.user_id:
+        parts.append(f"user:{args.user_id}")
+    if args.job_id:
+        parts.append(f"job:{args.job_id}")
+    if args.lease_id:
+        parts.append(f"lease:{args.lease_id}")
+    if args.proxy_url:
+        parts.append("runtime:VALET")
+    return ", ".join(parts) if parts else "local only"
+
+
+def _validate_path(value: str | None, label: str) -> None:
+    if not value:
+        return
+    path = Path(value).expanduser()
+    if not path.exists():
+        raise SystemExit(f"{label} path does not exist: {value}")
+
+
+def _normalize_path(value: str | None) -> str | None:
+    if not value:
+        return None
+    return str(Path(value).expanduser())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ghosthands"
-version = "0.2.1"
+version = "0.2.2"
 description = "GhostHands v2 — Job application automation agent built on browser-use"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/ci/test_cli_args.py
+++ b/tests/ci/test_cli_args.py
@@ -11,16 +11,18 @@ patch sys.argv for each test.
 
 from __future__ import annotations
 
+import argparse
 import sys
 import types
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Module-level setup: mock heavy imports before loading ghosthands.cli
 # ---------------------------------------------------------------------------
+
 
 def _ensure_cli_importable():
     """Install lightweight mocks for browser-use dependency chain.
@@ -62,30 +64,32 @@ def _ensure_cli_importable():
         mock_prompts = sys.modules["ghosthands.agent.prompts"]
     if "ghosthands.agent.hooks" not in sys.modules:
         mock_hooks = types.ModuleType("ghosthands.agent.hooks")
-        mock_hooks.install_same_tab_guard = AsyncMock()
-        mock_hooks.install_final_submit_guard = AsyncMock()
-        mock_hooks.consume_blocked_final_submit = AsyncMock(return_value=None)
+        hooks_any = cast(Any, mock_hooks)
+        hooks_any.install_same_tab_guard = AsyncMock()
+        hooks_any.install_final_submit_guard = AsyncMock()
+        hooks_any.consume_blocked_final_submit = AsyncMock(return_value=None)
         sys.modules["ghosthands.agent.hooks"] = mock_hooks
     else:
         mock_hooks = sys.modules["ghosthands.agent.hooks"]
 
-    setattr(mock_agent, "factory", mock_factory)
-    setattr(mock_agent, "prompts", mock_prompts)
-    setattr(mock_agent, "hooks", mock_hooks)
+    agent_any = cast(Any, mock_agent)
+    agent_any.factory = mock_factory
+    agent_any.prompts = mock_prompts
+    agent_any.hooks = mock_hooks
 
 
 _ensure_cli_importable()
 
 from ghosthands.cli import parse_args  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _parse(argv: list[str]) -> object:
+
+def _parse(argv: list[str]) -> argparse.Namespace:
     """Run parse_args() with a synthetic sys.argv."""
-    with patch.object(sys, "argv", ["hand-x"] + argv):
+    with patch.object(sys, "argv", ["hand-x", *argv]):
         return parse_args()
 
 
@@ -155,26 +159,38 @@ class TestProfileArgs:
 
     def test_profile_inline_json(self):
         """--profile accepts an inline JSON string."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--profile", '{"name": "Jane Doe"}',
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--profile",
+                '{"name": "Jane Doe"}',
+            ]
+        )
         assert args.profile == '{"name": "Jane Doe"}'
 
     def test_profile_at_filepath(self):
         """--profile accepts @filepath syntax (string is passed through as-is)."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--profile", "@/tmp/profile.json",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--profile",
+                "@/tmp/profile.json",
+            ]
+        )
         assert args.profile == "@/tmp/profile.json"
 
     def test_test_data_path(self):
         """--test-data stores a file path string."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--test-data", "examples/sample.json",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--test-data",
+                "examples/sample.json",
+            ]
+        )
         assert args.test_data == "examples/sample.json"
 
     def test_profile_default_none(self):
@@ -265,6 +281,11 @@ class TestOutputFormat:
         args = _parse(["--job-url", "https://example.com", "--output-format", "human"])
         assert args.output_format == "human"
 
+    def test_output_format_tui(self):
+        """--output-format accepts 'tui'."""
+        args = _parse(["--output-format", "tui"])
+        assert args.output_format == "tui"
+
     def test_output_format_jsonl_explicit(self):
         """--output-format accepts explicit 'jsonl'."""
         args = _parse(["--job-url", "https://example.com", "--output-format", "jsonl"])
@@ -307,10 +328,14 @@ class TestProxyArgs:
 
     def test_proxy_url_set(self):
         """--proxy-url stores the provided URL."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--proxy-url", "https://valet.example.com/api/v1/local-workers/anthropic",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--proxy-url",
+                "https://valet.example.com/api/v1/local-workers/anthropic",
+            ]
+        )
         assert args.proxy_url == "https://valet.example.com/api/v1/local-workers/anthropic"
 
     def test_runtime_grant_default_none(self):
@@ -320,10 +345,14 @@ class TestProxyArgs:
 
     def test_runtime_grant_set(self):
         """--runtime-grant stores the provided token."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--runtime-grant", "lwrg_v1_abc123",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--runtime-grant",
+                "lwrg_v1_abc123",
+            ]
+        )
         assert args.runtime_grant == "lwrg_v1_abc123"
 
 
@@ -342,10 +371,14 @@ class TestDesktopBridgeArgs:
 
     def test_cdp_url_set(self):
         """--cdp-url stores the provided CDP URL."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--cdp-url", "ws://127.0.0.1:9222/devtools/browser/abc",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--cdp-url",
+                "ws://127.0.0.1:9222/devtools/browser/abc",
+            ]
+        )
         assert args.cdp_url == "ws://127.0.0.1:9222/devtools/browser/abc"
 
     def test_engine_default_auto(self):
@@ -355,27 +388,39 @@ class TestDesktopBridgeArgs:
 
     def test_engine_chromium(self):
         """--engine accepts chromium."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--engine", "chromium",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--engine",
+                "chromium",
+            ]
+        )
         assert args.engine == "chromium"
 
     def test_engine_firefox(self):
         """--engine accepts firefox."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--engine", "firefox",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--engine",
+                "firefox",
+            ]
+        )
         assert args.engine == "firefox"
 
     def test_engine_invalid_rejected(self):
         """--engine rejects invalid values."""
         with pytest.raises(SystemExit):
-            _parse([
-                "--job-url", "https://example.com",
-                "--engine", "webkit",
-            ])
+            _parse(
+                [
+                    "--job-url",
+                    "https://example.com",
+                    "--engine",
+                    "webkit",
+                ]
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -393,10 +438,14 @@ class TestPathArgs:
 
     def test_resume_set(self):
         """--resume stores the provided file path."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--resume", "/tmp/resume.pdf",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--resume",
+                "/tmp/resume.pdf",
+            ]
+        )
         assert args.resume == "/tmp/resume.pdf"
 
     def test_browsers_path_default_none(self):
@@ -406,10 +455,14 @@ class TestPathArgs:
 
     def test_browsers_path_set(self):
         """--browsers-path stores the provided path."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--browsers-path", "/opt/playwright/browsers",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--browsers-path",
+                "/opt/playwright/browsers",
+            ]
+        )
         assert args.browsers_path == "/opt/playwright/browsers"
 
 
@@ -428,10 +481,14 @@ class TestMiscArgs:
 
     def test_model_set(self):
         """--model stores the provided model name."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--model", "claude-sonnet-4-20250514",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--model",
+                "claude-sonnet-4-20250514",
+            ]
+        )
         assert args.model == "claude-sonnet-4-20250514"
 
     def test_job_id_default_empty(self):
@@ -441,10 +498,14 @@ class TestMiscArgs:
 
     def test_job_id_set(self):
         """--job-id stores the provided value."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--job-id", "job-abc-123",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--job-id",
+                "job-abc-123",
+            ]
+        )
         assert args.job_id == "job-abc-123"
 
     def test_lease_id_default_empty(self):
@@ -454,10 +515,14 @@ class TestMiscArgs:
 
     def test_lease_id_set(self):
         """--lease-id stores the provided value."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--lease-id", "lease-xyz",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--lease-id",
+                "lease-xyz",
+            ]
+        )
         assert args.lease_id == "lease-xyz"
 
 
@@ -480,6 +545,18 @@ class TestApplySubcommand:
         assert args.job_url == "https://example.com"
 
 
+class TestTuiSubcommand:
+    """Tests for the terminal UI command alias."""
+
+    def test_tui_subcommand_sets_output_format(self):
+        args = _parse(["tui"])
+        assert args.output_format == "tui"
+
+    def test_terminal_subcommand_sets_output_format(self):
+        args = _parse(["terminal"])
+        assert args.output_format == "tui"
+
+
 # ---------------------------------------------------------------------------
 # Documenting gaps for future streams
 # ---------------------------------------------------------------------------
@@ -500,26 +577,38 @@ class TestAllowedDomains:
 
     def test_allowed_domains_single(self):
         """--allowed-domains accepts a single domain."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--allowed-domains", "greenhouse.io",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--allowed-domains",
+                "greenhouse.io",
+            ]
+        )
         assert args.allowed_domains == "greenhouse.io"
 
     def test_allowed_domains_comma_separated(self):
         """--allowed-domains accepts a comma-separated list."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--allowed-domains", "greenhouse.io,lever.co,sso.company.com",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--allowed-domains",
+                "greenhouse.io,lever.co,sso.company.com",
+            ]
+        )
         assert args.allowed_domains == "greenhouse.io,lever.co,sso.company.com"
 
     def test_allowed_domains_is_string(self):
         """--allowed-domains is stored as a raw string (parsed later in CLI flow)."""
-        args = _parse([
-            "--job-url", "https://example.com",
-            "--allowed-domains", "example.com",
-        ])
+        args = _parse(
+            [
+                "--job-url",
+                "https://example.com",
+                "--allowed-domains",
+                "example.com",
+            ]
+        )
         assert isinstance(args.allowed_domains, str)
 
 
@@ -538,7 +627,10 @@ class TestFutureGaps:
         inside run_agent_jsonl/run_agent_human, but is not exposed as a CLI flag.
         """
         with pytest.raises(SystemExit):
-            _parse([
-                "--job-url", "https://example.com",
-                "--keep-alive",
-            ])
+            _parse(
+                [
+                    "--job-url",
+                    "https://example.com",
+                    "--keep-alive",
+                ]
+            )

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -1,0 +1,137 @@
+"""Tests for the terminal UI JSONL adapter."""
+
+from __future__ import annotations
+
+import argparse
+import io
+
+from rich.console import Console
+
+from ghosthands.tui import TuiRunState, _render_state, build_engine_argv, parse_jsonl_event
+
+
+def _args(**overrides):
+    values = {
+        "job_url": "https://example.com/job",
+        "profile": '{"first_name":"Jane"}',
+        "test_data": None,
+        "user_id": None,
+        "resume_id": None,
+        "resume": "/tmp/resume.pdf",
+        "job_id": "",
+        "lease_id": "",
+        "model": None,
+        "max_steps": 50,
+        "max_budget": 0.5,
+        "submit_intent": "review",
+        "proxy_url": None,
+        "runtime_grant": None,
+        "allowed_domains": None,
+        "browsers_path": None,
+        "cdp_url": None,
+        "engine": "auto",
+        "headless": False,
+        "output_format": "tui",
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_parse_jsonl_event_rejects_non_events():
+    assert parse_jsonl_event("not-json") is None
+    assert parse_jsonl_event("[]") is None
+    assert parse_jsonl_event('{"timestamp":1}') is None
+
+
+def test_tui_state_tracks_core_events():
+    state = TuiRunState()
+    for line in (
+        '{"event":"handshake","protocol_version":1}',
+        '{"event":"phase","phase":"Starting application"}',
+        '{"event":"status","message":"Step 2","step":2,"maxSteps":50}',
+        '{"event":"field_filled","field":"email","value":"jane@example.com"}',
+        '{"event":"cost","total_usd":0.0123,"prompt_tokens":10,"completion_tokens":5}',
+        '{"event":"awaiting_review","message":"Review now","pageUrl":"https://example.com/review"}',
+    ):
+        event = parse_jsonl_event(line)
+        assert event is not None
+        state.apply_event(event)
+
+    assert state.phase == "Review"
+    assert state.step == 2
+    assert state.max_steps == 50
+    assert state.fields_filled == 1
+    assert state.cost_usd == 0.0123
+    assert state.awaiting_review is True
+    assert state.page_url == "https://example.com/review"
+
+
+def test_tui_state_tracks_sync_events():
+    state = TuiRunState(job_id="job-1", lease_id="lease-1", sync_status="VALET sync pending")
+
+    for line in (
+        '{"event":"lease_acquired","leaseId":"lease-1","jobId":"job-1"}',
+        '{"event":"lease_heartbeat","leaseId":"lease-1"}',
+        '{"event":"lease_released","leaseId":"lease-1","reason":"completed"}',
+    ):
+        event = parse_jsonl_event(line)
+        assert event is not None
+        state.apply_event(event)
+
+    assert state.job_id == "job-1"
+    assert state.lease_id == "lease-1"
+    assert state.sync_status == "VALET released (completed)"
+    assert state.logs[-1] == ("sync", "VALET released (completed)")
+
+
+def test_tui_state_redacts_password_values():
+    state = TuiRunState()
+    event = parse_jsonl_event('{"event":"field_filled","field":"password","value":"secret"}')
+    assert event is not None
+
+    state.apply_event(event)
+
+    assert state.logs[-1] == ("filled", "password: [redacted]")
+
+
+def test_tui_render_treats_log_messages_as_plain_text():
+    state = TuiRunState()
+    event = parse_jsonl_event('{"event":"field_filled","field":"password","value":"secret"}')
+    assert event is not None
+    state.apply_event(event)
+    output = io.StringIO()
+    console = Console(file=output, width=100, force_terminal=False)
+
+    console.print(_render_state(state))
+
+    assert "password: [redacted]" in output.getvalue()
+
+
+def test_tui_render_shows_sync_status():
+    state = TuiRunState(job_id="job-1", lease_id="lease-1", sync_status="VALET sync active")
+    output = io.StringIO()
+    console = Console(file=output, width=120, force_terminal=False)
+
+    console.print(_render_state(state))
+
+    text = output.getvalue()
+    assert "VALET sync active" in text
+    assert "job-1" in text
+    assert "lease-1" in text
+
+
+def test_build_engine_argv_forces_jsonl_child_mode():
+    argv = build_engine_argv(_args(), executable=["hand-x"])
+
+    assert argv[:1] == ["hand-x"]
+    assert "--output-format" in argv
+    assert argv[argv.index("--output-format") + 1] == "jsonl"
+    assert "tui" not in argv
+    assert "--job-url" in argv
+    assert argv[argv.index("--job-url") + 1] == "https://example.com/job"
+
+
+def test_build_engine_argv_passes_headless_flag_only_when_enabled():
+    argv = build_engine_argv(_args(headless=True), executable=["hand-x"])
+
+    assert "--headless" in argv


### PR DESCRIPTION
## Summary
- add the Rich terminal adapter over the existing Hand-X JSONL/stdin contract
- keep final submit disabled by default and surface browser/review/lease/cost state
- restore four-platform Hand-X binary builds and block partial releases
- bump Hand-X to 0.2.2

## Verification
- `uv run pytest tests/unit/test_tui.py tests/ci/test_cli_args.py -q` (62 passed)
- focused pre-commit hooks passed
- `uv run hand-x --version` -> 0.2.2

No external application submission was triggered.