### PR TITLE
feat: add VALET review-only terminal runtime

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1820,6 +1820,18 @@ class BrowserSession(BaseModel):
 			# Get browser targets from SessionManager (source of truth)
 			# SessionManager has already discovered all targets via start_monitoring()
 			page_targets_from_manager = self.session_manager.get_all_page_targets()
+			requested_target_id = self._initial_target_id
+			selected_target = None
+			if requested_target_id:
+				selected_target = next(
+					(target for target in page_targets_from_manager if target.target_id == requested_target_id),
+					None,
+				)
+				if selected_target is None:
+					raise RuntimeError(
+						f'Requested Chrome target {requested_target_id} was not found; refusing to use or create another tab'
+					)
+			initial_targets = [selected_target] if selected_target is not None else page_targets_from_manager
 
 			# Check for chrome://newtab pages and redirect them to about:blank (in parallel)
 			from browser_use.utils import is_new_tab_page
@@ -1837,7 +1849,7 @@ class BrowserSession(BaseModel):
 
 			redirect_tasks = [
 				_redirect_newtab(target)
-				for target in page_targets_from_manager
+				for target in initial_targets
 				if is_new_tab_page(target.url) and target.url != 'about:blank'
 			]
 			if redirect_tasks:
@@ -1845,25 +1857,17 @@ class BrowserSession(BaseModel):
 
 			# Ensure we have at least one page
 			if not page_targets_from_manager:
+				if requested_target_id:
+					raise RuntimeError(
+						f'Requested Chrome target {requested_target_id} was not found; refusing to create a replacement tab'
+					)
 				new_target = await self._cdp_client_root.send.Target.createTarget(params={'url': 'about:blank'})
 				target_id = new_target['targetId']
 				self.logger.debug(f'📄 Created new blank page: {target_id}')
 			else:
-				# If a specific target_id was requested (e.g. Desktop shared-browser tab),
-				# attach to that target instead of defaulting to the first one.
-				requested_target_id = getattr(self, '_initial_target_id', None)
-				if requested_target_id:
-					known_ids = {t.target_id for t in page_targets_from_manager}
-					if requested_target_id in known_ids:
-						target_id = requested_target_id
-						self.logger.debug(f'📄 Attaching to requested target: {target_id}')
-					else:
-						self.logger.warning(
-							f'Requested target_id {requested_target_id} not found among '
-							f'{len(page_targets_from_manager)} discovered targets, '
-							f'falling back to first available target'
-						)
-						target_id = page_targets_from_manager[0].target_id
+				if selected_target is not None:
+					target_id = selected_target.target_id
+					self.logger.debug(f'📄 Attaching to requested target: {target_id}')
 				else:
 					target_id = page_targets_from_manager[0].target_id
 					self.logger.debug(f'📄 Using existing page: {target_id}')
@@ -1894,7 +1898,7 @@ class BrowserSession(BaseModel):
 					self.logger.warning('Target created but title is unknown (may be normal for about:blank)')
 
 			# Dispatch TabCreatedEvent for all initial tabs (so watchdogs can initialize)
-			for idx, target in enumerate(page_targets_from_manager):
+			for idx, target in enumerate(initial_targets):
 				target_url = target.url
 				self.logger.debug(f'Dispatching TabCreatedEvent for initial tab {idx}: {target_url}')
 				self.event_bus.dispatch(TabCreatedEvent(url=target_url, target_id=target.target_id))

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -879,9 +879,13 @@ class BrowserSession(BaseModel):
 	async def on_NavigateToUrlEvent(self, event: NavigateToUrlEvent) -> None:
 		"""Handle navigation requests - core browser functionality."""
 		self.logger.debug(f'[on_NavigateToUrlEvent] Received NavigateToUrlEvent: url={event.url}, new_tab={event.new_tab}')
+		if self._initial_target_id and self.agent_focus_target_id != self._initial_target_id:
+			raise RuntimeError(f'Browser session lost locked Chrome target {self._initial_target_id}')
 		if not self.agent_focus_target_id:
 			self.logger.warning('Cannot navigate - browser not connected')
 			return
+		if self._initial_target_id:
+			event.new_tab = False
 
 		target_id = None
 		current_target_id = self.agent_focus_target_id
@@ -1098,6 +1102,10 @@ class BrowserSession(BaseModel):
 		"""Handle tab switching - core browser functionality."""
 		if not self.agent_focus_target_id:
 			raise RuntimeError('Cannot switch tabs - browser not connected')
+		if self._initial_target_id and event.target_id != self._initial_target_id:
+			raise RuntimeError(
+				f'Browser session is locked to Chrome target {self._initial_target_id}; refusing to switch tabs'
+			)
 
 		# Get all page targets
 		page_targets = self.session_manager.get_all_page_targets()
@@ -1140,6 +1148,10 @@ class BrowserSession(BaseModel):
 
 	async def on_CloseTabEvent(self, event: CloseTabEvent) -> None:
 		"""Handle tab closure - update focus if needed."""
+		if self._initial_target_id:
+			raise RuntimeError(
+				f'Browser session is locked to Chrome target {self._initial_target_id}; refusing to close tabs'
+			)
 		try:
 			# Dispatch tab closed event
 			await self.event_bus.dispatch(TabClosedEvent(target_id=event.target_id))
@@ -1184,6 +1196,9 @@ class BrowserSession(BaseModel):
 		current_target_id = self.agent_focus_target_id
 
 		# If the closed tab was the current one, find a new target
+		if current_target_id == event.target_id and self._initial_target_id:
+			self.agent_focus_target_id = None
+			return
 		if current_target_id == event.target_id:
 			await self.event_bus.dispatch(SwitchTabEvent(target_id=None))
 
@@ -1283,6 +1298,10 @@ class BrowserSession(BaseModel):
 
 	async def new_page(self, url: str | None = None) -> 'Page':
 		"""Create a new page (tab)."""
+		if self._initial_target_id:
+			raise RuntimeError(
+				f'Browser session is locked to Chrome target {self._initial_target_id}; refusing to create a new tab'
+			)
 		from cdp_use.cdp.target.commands import CreateTargetParameters
 
 		params: CreateTargetParameters = {'url': url or 'about:blank'}
@@ -1320,6 +1339,8 @@ class BrowserSession(BaseModel):
 		from browser_use.actor.page import Page as PageActor
 
 		page_targets = self.session_manager.get_all_page_targets() if self.session_manager else []
+		if self._initial_target_id:
+			page_targets = [target for target in page_targets if target.target_id == self._initial_target_id]
 
 		targets = []
 		for target in page_targets:
@@ -1345,7 +1366,10 @@ class BrowserSession(BaseModel):
 		"""
 		if not self.session_manager:
 			return []
-		return self.session_manager.get_all_page_targets()
+		page_targets = self.session_manager.get_all_page_targets()
+		if self._initial_target_id:
+			return [target for target in page_targets if target.target_id == self._initial_target_id]
+		return page_targets
 
 	async def close_page(self, page: 'Union[Page, str]') -> None:
 		"""Close a page by Page object or target ID."""
@@ -1358,6 +1382,10 @@ class BrowserSession(BaseModel):
 			target_id = page._target_id
 		else:
 			target_id = str(page)
+		if self._initial_target_id:
+			raise RuntimeError(
+				f'Browser session is locked to Chrome target {self._initial_target_id}; refusing to close tabs'
+			)
 
 		params: CloseTargetParameters = {'targetId': target_id}
 		await self.cdp_client.send.Target.closeTarget(params)
@@ -1433,6 +1461,13 @@ class BrowserSession(BaseModel):
 		Raises:
 			ValueError: If target doesn't exist or session is not available.
 		"""
+		if self._initial_target_id:
+			if target_id is None:
+				target_id = self._initial_target_id
+			elif target_id != self._initial_target_id:
+				raise ValueError(
+					f'Browser session is locked to Chrome target {self._initial_target_id}; refusing target {target_id}'
+				)
 		assert self._cdp_client_root is not None, 'Root CDP client not initialized'
 		assert self.session_manager is not None, 'SessionManager not initialized'
 
@@ -2126,17 +2161,22 @@ class BrowserSession(BaseModel):
 		# 6. Re-discover page targets and restore focus
 		page_targets = self.session_manager.get_all_page_targets()
 
-		# Prefer the old focus target if it still exists
+		# Prefer the selected target if this is an exact-target Desktop session.
 		restored = False
-		if old_focus_target_id:
+		restore_target_id = self._initial_target_id or old_focus_target_id
+		if restore_target_id:
 			for target in page_targets:
-				if target.target_id == old_focus_target_id:
-					await self.get_or_create_cdp_session(old_focus_target_id, focus=True)
+				if target.target_id == restore_target_id:
+					await self.get_or_create_cdp_session(restore_target_id, focus=True)
 					restored = True
-					self.logger.debug(f'🔄 Restored agent focus to previous target {old_focus_target_id[:8]}...')
+					self.logger.debug(f'🔄 Restored agent focus to previous target {restore_target_id[:8]}...')
 					break
 
 		if not restored:
+			if self._initial_target_id:
+				raise RuntimeError(
+					f'Requested Chrome target {self._initial_target_id} disappeared during reconnect; refusing fallback'
+				)
 			if page_targets:
 				fallback_id = page_targets[0].target_id
 				await self.get_or_create_cdp_session(fallback_id, focus=True)
@@ -3196,6 +3236,8 @@ class BrowserSession(BaseModel):
 
 	async def _close_extension_options_pages(self) -> None:
 		"""Close any extension options/welcome pages that have opened."""
+		if self._initial_target_id:
+			return
 		try:
 			# Get all page targets from SessionManager
 			page_targets = self.session_manager.get_all_page_targets()
@@ -3289,6 +3331,10 @@ class BrowserSession(BaseModel):
 
 	async def _cdp_create_new_page(self, url: str = 'about:blank', background: bool = False, new_window: bool = False) -> str:
 		"""Create a new page/tab using CDP Target.createTarget. Returns target ID."""
+		if self._initial_target_id:
+			raise RuntimeError(
+				f'Browser session is locked to Chrome target {self._initial_target_id}; refusing to create a new tab'
+			)
 		# Only include newWindow when True, letting Chrome auto-create window as needed
 		params = CreateTargetParameters(url=url, background=background)
 		if new_window:
@@ -3303,6 +3349,10 @@ class BrowserSession(BaseModel):
 
 	async def _cdp_close_page(self, target_id: TargetID) -> None:
 		"""Close a page/tab using CDP Target.closeTarget."""
+		if self._initial_target_id:
+			raise RuntimeError(
+				f'Browser session is locked to Chrome target {self._initial_target_id}; refusing to close tabs'
+			)
 		await self.cdp_client.send.Target.closeTarget(params={'targetId': target_id})
 
 	async def _cdp_get_cookies(self) -> list[Cookie]:

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -136,7 +136,7 @@ class SessionManager:
 				self.browser_session.agent_focus_target_id = None
 
 				# Trigger recovery if not already in progress
-				if not self._recovery_in_progress:
+				if not self._recovery_in_progress and not self.browser_session._initial_target_id:
 					self.logger.warning('[SessionManager] Recovery was not in progress! Triggering now.')
 					self._recovery_task = create_task_with_error_handling(
 						self._recover_agent_focus(target_id),
@@ -610,6 +610,11 @@ class SessionManager:
 		try:
 			if getattr(self.browser_session, '_detaching_keep_alive', False):
 				self.logger.debug('[SessionManager] Skipping focus recovery during keep-alive detach')
+				return
+			if getattr(self.browser_session, '_initial_target_id', None):
+				self.logger.error(
+					f'[SessionManager] Exact Chrome target {self.browser_session._initial_target_id} was lost; refusing focus recovery'
+				)
 				return
 
 			# Prevent concurrent recovery attempts

--- a/ghosthands/actions/domhand_fill.py
+++ b/ghosthands/actions/domhand_fill.py
@@ -323,6 +323,57 @@ PRE_LLM_OPTION_ENRICHMENT_SETTLE_MATCHES = 2
 MAX_CONDITIONAL_PASSES = 3
 DEFAULT_HITL_TIMEOUT_SECONDS = int(os.getenv("GH_OPEN_QUESTION_TIMEOUT_SECONDS", "5400"))
 
+
+async def _resolve_required_human_answer(
+    field: FormField,
+    proposed: ResolvedFieldValue | None,
+) -> ResolvedFieldValue | None:
+    """Ask the active JSONL host when a required field has no grounded answer."""
+    unresolved = (
+        proposed is None
+        or not proposed.value
+        or proposed.answer_mode == "best_effort_guess"
+        or "[NEEDS_USER_INPUT]" in proposed.value.upper()
+    )
+    if not field.required or not unresolved:
+        return proposed
+
+    from ghosthands.bridge.protocol import get_field_answer, is_hitl_available, wait_for_run_resume
+
+    if not is_hitl_available():
+        return None
+
+    from ghosthands.output.jsonl import emit_needs_answer, emit_run_state
+
+    label = _preferred_field_label(field)
+    emit_needs_answer(
+        field_id=field.field_id,
+        label=label,
+        field_type=field.field_type or "text",
+        options=list(field.options or field.choices),
+        required=True,
+        section=field.section or "",
+    )
+    answer = await get_field_answer(
+        field.field_id,
+        timeout=DEFAULT_HITL_TIMEOUT_SECONDS,
+        field_label=label,
+    )
+    if not await wait_for_run_resume():
+        return None
+    emit_run_state("running", message="Input received")
+    if answer is None or answer == "":
+        return None
+    coerced = _coerce_answer_to_field(field, answer)
+    if not coerced:
+        return None
+    return _resolved_field_value(
+        coerced,
+        source="human",
+        answer_mode="human_supplied",
+        confidence=1.0,
+    )
+
 # Selector for all interactive form elements (matches GH formFiller.ts).
 INTERACTIVE_SELECTOR = ", ".join(
     [
@@ -2941,6 +2992,10 @@ async def _stagehand_observe_cross_reference(
 
 async def domhand_fill(params: DomHandFillParams, browser_session: BrowserSession) -> ActionResult:
     """Fill all visible form fields using fast DOM manipulation."""
+    from ghosthands.bridge.protocol import wait_for_run_resume
+
+    if not await wait_for_run_resume():
+        return ActionResult(error="Run cancelled while paused")
     # If previous fill was killed by timeout, note what it did.
     # This prefix goes into the ActionResult so the agent knows fields are likely done.
     _prev = getattr(browser_session, "_gh_fill_partial", None)
@@ -3133,6 +3188,8 @@ async def domhand_fill(params: DomHandFillParams, browser_session: BrowserSessio
     browser_session._gh_fill_partial = _partial
 
     for round_num in range(1, MAX_FILL_ROUNDS + 1):
+        if not await wait_for_run_resume():
+            return ActionResult(error="Run cancelled while paused")
         logger.info(f"DomHand fill round {round_num}/{MAX_FILL_ROUNDS}")
 
         try:
@@ -3914,6 +3971,8 @@ async def domhand_fill(params: DomHandFillParams, browser_session: BrowserSessio
                         confidence=0.95,
                     ),
                 )
+                if not await wait_for_run_resume():
+                    return ActionResult(error="Run cancelled while paused")
                 success, field_error, failure_reason, fc, settled_value = await _attempt_domhand_fill_with_retry_cap(
                     page,
                     host=page_host,
@@ -3999,6 +4058,7 @@ async def domhand_fill(params: DomHandFillParams, browser_session: BrowserSessio
             if resolved_value and "[NEEDS_USER_INPUT]" in resolved_value.value:
                 _rejection_reason = "needs_user_input"
                 resolved_value = None
+            resolved_value = await _resolve_required_human_answer(f, resolved_value)
             if not resolved_value or not resolved_value.value:
                 if not _rejection_reason:
                     _rejection_reason = "resolve_returned_none"
@@ -4043,6 +4103,8 @@ async def domhand_fill(params: DomHandFillParams, browser_session: BrowserSessio
                 fields_skipped.add(key)
                 continue
             matched_answer = resolved_value.value
+            if not await wait_for_run_resume():
+                return ActionResult(error="Run cancelled while paused")
             success, field_error, failure_reason, fc, settled_value = await _attempt_domhand_fill_with_retry_cap(
                 page,
                 host=page_host,

--- a/ghosthands/actions/domhand_fill.py
+++ b/ghosthands/actions/domhand_fill.py
@@ -338,7 +338,12 @@ async def _resolve_required_human_answer(
     if not field.required or not unresolved:
         return proposed
 
-    from ghosthands.bridge.protocol import get_field_answer, is_hitl_available, wait_for_run_resume
+    from ghosthands.bridge.protocol import (
+        consume_field_answer_save,
+        get_field_answer,
+        is_hitl_available,
+        wait_for_run_resume,
+    )
 
     if not is_hitl_available():
         return None
@@ -359,6 +364,7 @@ async def _resolve_required_human_answer(
         timeout=DEFAULT_HITL_TIMEOUT_SECONDS,
         field_label=label,
     )
+    save_answer = consume_field_answer_save(field.field_id, field_label=label)
     if not await wait_for_run_resume():
         return None
     emit_run_state("running", message="Input received")
@@ -370,7 +376,7 @@ async def _resolve_required_human_answer(
     return _resolved_field_value(
         coerced,
         source="human",
-        answer_mode="human_supplied",
+        answer_mode="human_saved" if save_answer else "human_supplied",
         confidence=1.0,
     )
 

--- a/ghosthands/actions/domhand_fill_repeaters.py
+++ b/ghosthands/actions/domhand_fill_repeaters.py
@@ -8,6 +8,7 @@ Supported sections: Education, Work Experience, Skills, Languages, Licenses.
 """
 
 import asyncio
+import contextlib
 import json
 import structlog
 import os
@@ -196,6 +197,7 @@ _FIND_SAVE_BUTTON_JS = r"""
         // Same pattern as domhand_expand's tagAndReturn.
         btn.setAttribute('data-dh-commit-target', 'true');
         btn.scrollIntoView({block: 'center', behavior: 'instant'});
+        diag.phase = phase;
         return JSON.stringify(Object.assign({
             found: true,
             text: btn.textContent.trim(),
@@ -235,18 +237,6 @@ _FIND_SAVE_BUTTON_JS = r"""
 
     var pageBtns = document.querySelectorAll('button, [role="button"]');
 
-    if (sectionCommitPattern) {
-        for (const btn of pageBtns) {
-            const text = (btn.textContent || '').trim();
-            if (sectionCommitPattern.test(text)) {
-                var s = getComputedStyle(btn);
-                if (s.display !== 'none' && s.visibility !== 'hidden') {
-                    return tagAndReturn(btn, 'oracle_section_commit', {oracle_commit: true});
-                }
-            }
-        }
-    }
-
     if (preferSave) {
         for (const btn of pageBtns) {
             const text = (btn.textContent || '').trim().toLowerCase();
@@ -254,6 +244,18 @@ _FIND_SAVE_BUTTON_JS = r"""
                 var s = getComputedStyle(btn);
                 if (s.display !== 'none' && s.visibility !== 'hidden') {
                     return tagAndReturn(btn, 'oracle_save');
+                }
+            }
+        }
+    }
+
+    if (sectionCommitPattern && !preferSave) {
+        for (const btn of pageBtns) {
+            const text = (btn.textContent || '').trim();
+            if (sectionCommitPattern.test(text)) {
+                var s = getComputedStyle(btn);
+                if (s.display !== 'none' && s.visibility !== 'hidden') {
+                    return tagAndReturn(btn, 'oracle_section_commit', {oracle_commit: true});
                 }
             }
         }

--- a/ghosthands/agent/hooks.py
+++ b/ghosthands/agent/hooks.py
@@ -186,6 +186,19 @@ _FINAL_SUBMIT_GUARD_JS = r"""(() => {
 		}
 	}
 
+	function looksLikeApplicationForm(form) {
+		if (!form || !form.getAttribute) return false;
+		const identity = normalize([
+			form.id,
+			form.getAttribute('name'),
+			form.getAttribute('class'),
+			form.getAttribute('aria-label'),
+			form.getAttribute('data-automation-id'),
+			form.getAttribute('action'),
+		].filter(Boolean).join(' '));
+		return /(?:job|candidate)?\s*application|application\s*form|jobapplication/.test(identity);
+	}
+
 	function recordBlock(el) {
 		const text = normalize(getText(el));
 		window.__ghFinalSubmitGuardState = {
@@ -217,11 +230,13 @@ _FINAL_SUBMIT_GUARD_JS = r"""(() => {
 			text === 'next' ||
 			text === 'continue' ||
 			text.includes('continue to review') ||
-			text.includes('apply with resume') ||
-			text === 'apply'
+			text.includes('apply with resume')
 		) {
 			return false;
 		}
+		const applicationFormAction = looksLikeApplicationForm(form) && (
+			text === 'apply' || text === 'apply now' || text === 'finish'
+		);
 
 		return (
 			text === 'submit' ||
@@ -230,7 +245,8 @@ _FINAL_SUBMIT_GUARD_JS = r"""(() => {
 			text.includes('finish and submit') ||
 			text.includes('complete application') ||
 			text.includes('confirm and submit') ||
-			text.includes('send application')
+			text.includes('send application') ||
+			applicationFormAction
 		);
 	}
 
@@ -239,9 +255,9 @@ _FINAL_SUBMIT_GUARD_JS = r"""(() => {
 		if (candidate && looksLikeFinalSubmit(candidate)) return candidate.closest('button, input[type="submit"], input[type="button"], [role="button"]');
 		try {
 			const controls = Array.from(form.querySelectorAll('button, input[type="submit"], input[type="button"], [role="button"]'));
-			return controls.find(looksLikeFinalSubmit) || null;
+			return controls.find(looksLikeFinalSubmit) || (looksLikeApplicationForm(form) ? form : null);
 		} catch (e) {
-			return null;
+			return looksLikeApplicationForm(form) ? form : null;
 		}
 	}
 
@@ -346,35 +362,22 @@ async def install_same_tab_guard(agent: "Agent") -> None:
 
 
 async def install_final_submit_guard(agent: "Agent", *, allow_submit: bool) -> None:
-	"""Install a runtime guard that blocks final application submission by default."""
+	"""Install the review-mode submit guard, failing before automation if it cannot be installed."""
 	if allow_submit:
 		return
-	try:
-		browser_session = getattr(agent, "browser_session", None)
-		if browser_session is None:
-			return
+	browser_session = getattr(agent, "browser_session", None)
+	if browser_session is None:
+		raise RuntimeError("Review mode requires an active browser session for the final-submit guard")
 
-		session_key = id(browser_session)
-		if session_key not in _FINAL_SUBMIT_GUARD_INSTALLED:
-			try:
-				await browser_session._cdp_add_init_script(_FINAL_SUBMIT_GUARD_JS)
-				_FINAL_SUBMIT_GUARD_INSTALLED.add(session_key)
-			except Exception as exc:
-				logger.debug("step.final_submit_guard_init_failed", extra={"error": str(exc)})
+	session_key = id(browser_session)
+	if session_key not in _FINAL_SUBMIT_GUARD_INSTALLED:
+		await browser_session._cdp_add_init_script(_FINAL_SUBMIT_GUARD_JS)
+		_FINAL_SUBMIT_GUARD_INSTALLED.add(session_key)
 
-		pages = []
-		try:
-			pages = list(await browser_session.get_pages())
-		except Exception:
-			pages = []
-		if not pages:
-			page = await browser_session.get_current_page()
-			if page:
-				pages = [page]
-		for page in pages:
-			await page.evaluate(_FINAL_SUBMIT_GUARD_JS)
-	except Exception as exc:
-		logger.debug("step.final_submit_guard_apply_failed", extra={"error": str(exc)})
+	page = await browser_session.get_current_page()
+	if page is None:
+		raise RuntimeError("Review mode could not install the final-submit guard on the selected target")
+	await page.evaluate(_FINAL_SUBMIT_GUARD_JS)
 
 
 async def consume_blocked_final_submit(agent: "Agent") -> dict[str, Any] | None:

--- a/ghosthands/agent/hooks.py
+++ b/ghosthands/agent/hooks.py
@@ -161,13 +161,15 @@ _FINAL_SUBMIT_GUARD_JS = r"""(() => {
 
 	function getText(el) {
 		if (!el) return '';
-		return [
+		return ([
 			el.getAttribute && el.getAttribute('aria-label'),
 			el.getAttribute && el.getAttribute('title'),
 			el.value,
 			el.innerText,
 			el.textContent,
-		].filter(Boolean).join(' ');
+		].filter(Boolean).filter(function(value, index, values) {
+			return values.indexOf(value) === index;
+		}).join(' '));
 	}
 
 	function isVisible(el) {
@@ -186,19 +188,6 @@ _FINAL_SUBMIT_GUARD_JS = r"""(() => {
 		}
 	}
 
-	function looksLikeApplicationForm(form) {
-		if (!form || !form.getAttribute) return false;
-		const identity = normalize([
-			form.id,
-			form.getAttribute('name'),
-			form.getAttribute('class'),
-			form.getAttribute('aria-label'),
-			form.getAttribute('data-automation-id'),
-			form.getAttribute('action'),
-		].filter(Boolean).join(' '));
-		return /(?:job|candidate)?\s*application|application\s*form|jobapplication/.test(identity);
-	}
-
 	function recordBlock(el) {
 		const text = normalize(getText(el));
 		window.__ghFinalSubmitGuardState = {
@@ -209,55 +198,67 @@ _FINAL_SUBMIT_GUARD_JS = r"""(() => {
 		};
 	}
 
+	function controlFor(el) {
+		return el && el.closest ? el.closest('button, input[type="submit"], input[type="button"], [role="button"]') : null;
+	}
+
+	function isAllowedNonFinalControl(el) {
+		const control = controlFor(el);
+		if (!control) return false;
+		const text = normalize(getText(control));
+		const form = control.form || (control.closest ? control.closest('form') : null);
+		if (hasPasswordField(form)) return true;
+		return (
+			text === 'next' ||
+			text === 'continue' ||
+			text === 'save' ||
+			text === 'save and continue' ||
+			text === 'save & continue' ||
+			text === 'continue to review' ||
+			text === 'apply with resume' ||
+			text === 'autofill with resume'
+		);
+	}
+
 	function looksLikeFinalSubmit(el) {
-		const control = el && el.closest ? el.closest('button, input[type="submit"], input[type="button"], [role="button"]') : null;
+		const control = controlFor(el);
 		if (!control || !isVisible(control)) return false;
 		if (control.disabled) return false;
 		if (String(control.getAttribute && control.getAttribute('aria-disabled') || '').toLowerCase() === 'true') return false;
 
 		const form = control.form || (control.closest ? control.closest('form') : null);
 		if (hasPasswordField(form)) return false;
+		if (isAllowedNonFinalControl(control)) return false;
 
 		const text = normalize(getText(control));
-		if (!text) return false;
-		if (
-			text.includes('sign in') ||
-			text.includes('log in') ||
-			text.includes('login') ||
-			text.includes('create account') ||
-			text.includes('register') ||
-			text.includes('save and continue') ||
-			text === 'next' ||
-			text === 'continue' ||
-			text.includes('continue to review') ||
-			text.includes('apply with resume')
-		) {
-			return false;
-		}
-		const applicationFormAction = looksLikeApplicationForm(form) && (
-			text === 'apply' || text === 'apply now' || text === 'finish'
-		);
-
-		return (
+		const explicitFinalLabel = (
 			text === 'submit' ||
+			text === 'apply' ||
+			text === 'apply now' ||
+			text === 'finish' ||
 			text.includes('submit application') ||
 			text.includes('review and submit') ||
 			text.includes('finish and submit') ||
 			text.includes('complete application') ||
 			text.includes('confirm and submit') ||
-			text.includes('send application') ||
-			applicationFormAction
+			text.includes('send application')
 		);
+		if (explicitFinalLabel) return true;
+		if (!form) return false;
+		return control.matches('button:not([type]), button[type="submit"], input[type="submit"]');
 	}
 
 	function shouldBlockFormSubmit(form, candidate) {
 		if (hasPasswordField(form)) return false;
-		if (candidate && looksLikeFinalSubmit(candidate)) return candidate.closest('button, input[type="submit"], input[type="button"], [role="button"]');
+		if (candidate && isAllowedNonFinalControl(candidate)) return false;
+		if (candidate) return controlFor(candidate) || form;
 		try {
 			const controls = Array.from(form.querySelectorAll('button, input[type="submit"], input[type="button"], [role="button"]'));
-			return controls.find(looksLikeFinalSubmit) || (looksLikeApplicationForm(form) ? form : null);
+			const submitControls = controls.filter((control) => control.matches('button:not([type]), button[type="submit"], input[type="submit"]'));
+			if (submitControls.length === 1 && isAllowedNonFinalControl(submitControls[0])) return false;
+			return submitControls.find(looksLikeFinalSubmit) || form;
 		} catch (e) {
-			return looksLikeApplicationForm(form) ? form : null;
+			return form;
 		}
 	}
 

--- a/ghosthands/agent/hooks.py
+++ b/ghosthands/agent/hooks.py
@@ -19,6 +19,7 @@ These hooks are used to:
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from collections.abc import Awaitable, Callable
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 _SAME_TAB_GUARD_INSTALLED: set[int] = set()
 _FINAL_SUBMIT_GUARD_INSTALLED: set[int] = set()
 
-_SAME_TAB_GUARD_JS = r"""(() => {
+_SAME_TAB_GUARD_JS = r"""() => {
 	if (window.__ghSameTabGuardInstalled) {
 		try {
 			document.querySelectorAll('a[target], area[target], form[target]').forEach((el) => el.removeAttribute('target'));
@@ -148,9 +149,9 @@ _SAME_TAB_GUARD_JS = r"""(() => {
 	}
 
 	stripTargets(document);
-})();"""
+}"""
 
-_FINAL_SUBMIT_GUARD_JS = r"""(() => {
+_FINAL_SUBMIT_GUARD_JS = r"""() => {
 	if (window.__ghFinalSubmitGuardInstalled) return;
 	window.__ghFinalSubmitGuardInstalled = true;
 	window.__ghFinalSubmitGuardState = window.__ghFinalSubmitGuardState || { blocked: false, label: "", text: "", count: 0 };
@@ -202,21 +203,42 @@ _FINAL_SUBMIT_GUARD_JS = r"""(() => {
 		return el && el.closest ? el.closest('button, input[type="submit"], input[type="button"], [role="button"]') : null;
 	}
 
-	function isAllowedNonFinalControl(el) {
+	function isProvenNonFinalControl(el) {
 		const control = controlFor(el);
 		if (!control) return false;
 		const text = normalize(getText(control));
 		const form = control.form || (control.closest ? control.closest('form') : null);
-		if (hasPasswordField(form)) return true;
-		return (
+		if (
 			text === 'next' ||
 			text === 'continue' ||
 			text === 'save' ||
+			text === 'done' ||
+			text === 'ok' ||
 			text === 'save and continue' ||
 			text === 'save & continue' ||
 			text === 'continue to review' ||
 			text === 'apply with resume' ||
-			text === 'autofill with resume'
+			text === 'autofill with resume' ||
+			text === 'back' ||
+			text === 'previous' ||
+			text === 'cancel' ||
+			text === 'close' ||
+			text === 'edit' ||
+			text.startsWith('add ') ||
+			text.startsWith('upload ') ||
+			text.startsWith('attach ') ||
+			text.startsWith('select ') ||
+			text.startsWith('choose ') ||
+			text.startsWith('remove ')
+		) {
+			return true;
+		}
+		return hasPasswordField(form) && (
+			text === 'sign in' ||
+			text === 'log in' ||
+			text === 'login' ||
+			text === 'create account' ||
+			text === 'register'
 		);
 	}
 
@@ -227,35 +249,17 @@ _FINAL_SUBMIT_GUARD_JS = r"""(() => {
 		if (String(control.getAttribute && control.getAttribute('aria-disabled') || '').toLowerCase() === 'true') return false;
 
 		const form = control.form || (control.closest ? control.closest('form') : null);
-		if (hasPasswordField(form)) return false;
-		if (isAllowedNonFinalControl(control)) return false;
-
-		const text = normalize(getText(control));
-		const explicitFinalLabel = (
-			text === 'submit' ||
-			text === 'apply' ||
-			text === 'apply now' ||
-			text === 'finish' ||
-			text.includes('submit application') ||
-			text.includes('review and submit') ||
-			text.includes('finish and submit') ||
-			text.includes('complete application') ||
-			text.includes('confirm and submit') ||
-			text.includes('send application')
-		);
-		if (explicitFinalLabel) return true;
-		if (!form) return false;
-		return control.matches('button:not([type]), button[type="submit"], input[type="submit"]');
+		if (isProvenNonFinalControl(control)) return false;
+		return true;
 	}
 
 	function shouldBlockFormSubmit(form, candidate) {
-		if (hasPasswordField(form)) return false;
-		if (candidate && isAllowedNonFinalControl(candidate)) return false;
+		if (candidate && isProvenNonFinalControl(candidate)) return false;
 		if (candidate) return controlFor(candidate) || form;
 		try {
 			const controls = Array.from(form.querySelectorAll('button, input[type="submit"], input[type="button"], [role="button"]'));
 			const submitControls = controls.filter((control) => control.matches('button:not([type]), button[type="submit"], input[type="submit"]'));
-			if (submitControls.length === 1 && isAllowedNonFinalControl(submitControls[0])) return false;
+			if (submitControls.length === 1 && isProvenNonFinalControl(submitControls[0])) return false;
 			return submitControls.find(looksLikeFinalSubmit) || form;
 		} catch (e) {
 			return form;
@@ -312,9 +316,9 @@ _FINAL_SUBMIT_GUARD_JS = r"""(() => {
 		}
 		return nativeSubmit.call(this);
 	};
-})();"""
+}"""
 
-_READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS = r"""(() => {
+_READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS = r"""() => {
 	const state = window.__ghFinalSubmitGuardState || null;
 	if (!state || !state.blocked) return null;
 	window.__ghFinalSubmitGuardState = {
@@ -324,42 +328,29 @@ _READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS = r"""(() => {
 		count: Number(state.count || 0),
 	};
 	return state;
-})();"""
+}"""
 
 
 async def install_same_tab_guard(agent: "Agent") -> None:
-	"""Prevent sites from opening new tabs during job-application flows.
+	"""Install the same-tab guard and abort if target confinement cannot be enforced."""
+	browser_session = getattr(agent, "browser_session", None)
+	if browser_session is None:
+		raise RuntimeError("Same-tab confinement requires an active browser session")
 
-	This is best-effort:
-	- installs a CDP init script once per browser session so future documents inherit it
-	- reapplies the script on the current page every step to catch already-loaded DOM
-	"""
-	try:
-		browser_session = getattr(agent, "browser_session", None)
-		if browser_session is None:
-			return
+	session_key = id(browser_session)
+	if session_key not in _SAME_TAB_GUARD_INSTALLED:
+		await browser_session._cdp_add_init_script(f"({_SAME_TAB_GUARD_JS})()")
+		_SAME_TAB_GUARD_INSTALLED.add(session_key)
 
-		session_key = id(browser_session)
-		if session_key not in _SAME_TAB_GUARD_INSTALLED:
-			try:
-				await browser_session._cdp_add_init_script(_SAME_TAB_GUARD_JS)
-				_SAME_TAB_GUARD_INSTALLED.add(session_key)
-			except Exception as exc:
-				logger.debug("step.same_tab_guard_init_failed", extra={"error": str(exc)})
-
-		pages = []
-		try:
-			pages = list(await browser_session.get_pages())
-		except Exception:
-			pages = []
-		if not pages:
-			page = await browser_session.get_current_page()
-			if page:
-				pages = [page]
-		for page in pages:
-			await page.evaluate(_SAME_TAB_GUARD_JS)
-	except Exception as exc:
-		logger.debug("step.same_tab_guard_apply_failed", extra={"error": str(exc)})
+	pages = list(await browser_session.get_pages())
+	if not pages:
+		page = await browser_session.get_current_page()
+		if page:
+			pages = [page]
+	if not pages:
+		raise RuntimeError("Same-tab confinement could not find the selected browser target")
+	for page in pages:
+		await page.evaluate(_SAME_TAB_GUARD_JS)
 
 
 async def install_final_submit_guard(agent: "Agent", *, allow_submit: bool) -> None:
@@ -372,7 +363,7 @@ async def install_final_submit_guard(agent: "Agent", *, allow_submit: bool) -> N
 
 	session_key = id(browser_session)
 	if session_key not in _FINAL_SUBMIT_GUARD_INSTALLED:
-		await browser_session._cdp_add_init_script(_FINAL_SUBMIT_GUARD_JS)
+		await browser_session._cdp_add_init_script(f"({_FINAL_SUBMIT_GUARD_JS})()")
 		_FINAL_SUBMIT_GUARD_INSTALLED.add(session_key)
 
 	page = await browser_session.get_current_page()
@@ -383,17 +374,23 @@ async def install_final_submit_guard(agent: "Agent", *, allow_submit: bool) -> N
 
 async def consume_blocked_final_submit(agent: "Agent") -> dict[str, Any] | None:
 	"""Return and clear the latest blocked final-submit attempt, if any."""
-	try:
-		browser_session = getattr(agent, "browser_session", None)
-		if browser_session is None:
-			return None
-		page = await browser_session.get_current_page()
-		if page is None:
-			return None
-		state = await page.evaluate(_READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS)
-		return state if isinstance(state, dict) else None
-	except Exception:
+	browser_session = getattr(agent, "browser_session", None)
+	if browser_session is None:
+		raise RuntimeError("Review mode lost its browser session while checking the final-submit guard")
+	page = await browser_session.get_current_page()
+	if page is None:
+		raise RuntimeError("Review mode lost its selected target while checking the final-submit guard")
+	state = await page.evaluate(_READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS)
+	if isinstance(state, str):
+		try:
+			state = json.loads(state)
+		except json.JSONDecodeError as exc:
+			raise RuntimeError("Final-submit guard returned an invalid block state") from exc
+	if state is None:
 		return None
+	if not isinstance(state, dict):
+		raise RuntimeError("Final-submit guard returned an invalid block state")
+	return state
 
 PHASE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"upload.*resume|resume.*upload|attach.*resume", re.IGNORECASE), "Uploading resume"),

--- a/ghosthands/bridge/protocol.py
+++ b/ghosthands/bridge/protocol.py
@@ -23,6 +23,7 @@ logger = structlog.get_logger()
 _COMMAND_TYPES = frozenset(
     {
         "answer_field",
+        "save_answer",
         "skip_field",
         "pause_job",
         "resume_job",
@@ -41,11 +42,12 @@ def parse_bridge_command(line: str) -> dict[str, Any] | None:
         return None
     if not isinstance(command, dict) or command.get("type") not in _COMMAND_TYPES:
         return None
-    if command["type"] in {"answer_field", "skip_field"} and not (
+    if command["type"] in {"answer_field", "save_answer", "skip_field"} and not (
         str(command.get("field_id") or "").strip() or str(command.get("field_label") or "").strip()
     ):
         return None
     return command
+
 
 stdin_lock = asyncio.Lock()
 stdin_executor = concurrent.futures.ThreadPoolExecutor(
@@ -119,6 +121,7 @@ async def read_stdin_line(timeout: float | None = None) -> str:
 # and "Email" in emergency contact).  Falls back to field_label for
 # backward compatibility with older Desktop versions.
 _pending_answers: dict[str, str] = {}
+_saved_answer_keys: set[str] = set()
 _answer_events: dict[str, asyncio.Event] = {}
 _hitl_lock = asyncio.Lock()
 # M13: Cancel event — set when the run is cancelled so pending
@@ -140,6 +143,7 @@ def reset_hitl_state() -> None:
     """
     global _cancel_event, _hitl_available, _run_resume_event
     _pending_answers.clear()
+    _saved_answer_keys.clear()
     _answer_events.clear()
     _cancel_event = asyncio.Event()
     _run_resume_event = asyncio.Event()
@@ -205,7 +209,21 @@ def is_hitl_available() -> bool:
     return _hitl_available
 
 
-def put_field_answer(field_id: str, answer: str, *, field_label: str = "") -> None:
+def _normalize_field_answer(answer: Any) -> str:
+    if isinstance(answer, (list, tuple)):
+        return ", ".join(str(item).strip() for item in answer if str(item).strip())
+    if isinstance(answer, bool):
+        return "true" if answer else "false"
+    return str(answer or "")
+
+
+def put_field_answer(
+    field_id: str,
+    answer: Any,
+    *,
+    field_label: str = "",
+    save_answer: bool = False,
+) -> None:
     """Store an answer received from the Desktop for a pending HITL field.
 
     Parameters
@@ -222,7 +240,12 @@ def put_field_answer(field_id: str, answer: str, *, field_label: str = "") -> No
     key = field_id or field_label
     if not key:
         return
+    answer = _normalize_field_answer(answer)
     _pending_answers[key] = answer
+    if save_answer:
+        _saved_answer_keys.add(key)
+    else:
+        _saved_answer_keys.discard(key)
     evt = _answer_events.get(key)
     if evt:
         evt.set()
@@ -231,9 +254,21 @@ def put_field_answer(field_id: str, answer: str, *, field_label: str = "") -> No
     # legacy Desktop that only sends field_label.
     if field_label and field_label != key:
         _pending_answers[field_label] = answer
+        if save_answer:
+            _saved_answer_keys.add(field_label)
+        else:
+            _saved_answer_keys.discard(field_label)
         evt2 = _answer_events.get(field_label)
         if evt2:
             evt2.set()
+
+
+def consume_field_answer_save(field_id: str, *, field_label: str = "") -> bool:
+    """Consume whether the most recent answer requested verified-answer persistence."""
+    keys = {key for key in (field_id, field_label) if key}
+    saved = bool(keys & _saved_answer_keys)
+    _saved_answer_keys.difference_update(keys)
+    return saved
 
 
 async def get_field_answer(
@@ -295,7 +330,10 @@ async def get_field_answer(
 
         if answer_task in done:
             async with _hitl_lock:
-                return _pending_answers.pop(key, None)
+                answer = _pending_answers.pop(key, None)
+                if answer is None and field_label and field_label != key:
+                    answer = _pending_answers.pop(field_label, None)
+                return answer
 
         # Neither completed — timeout
         async with _hitl_lock:
@@ -373,14 +411,19 @@ async def listen_for_cancel(
                 target_id = getattr(getattr(agent, "browser_session", None), "agent_focus_target_id", None)
                 emit_resumed(job_id=job_id, target_id=target_id)
                 emit_run_state("running", job_id=job_id, target_id=target_id)
-        elif cmd_type == "answer_field":
+        elif cmd_type in {"answer_field", "save_answer"}:
             field_id = cmd.get("field_id", "")
             field_label = cmd.get("field_label", "")
             answer = cmd.get("answer", "")
             key = field_id or field_label
             if key:
                 logger.info("answer_field_received", field_id=field_id, field_label=field_label)
-                put_field_answer(field_id, answer, field_label=field_label)
+                put_field_answer(
+                    field_id,
+                    answer,
+                    field_label=field_label,
+                    save_answer=cmd_type == "save_answer" or cmd.get("save_answer") is True,
+                )
                 if not bool(getattr(agent.state, "paused", False)):
                     emit_run_state("running", message="Input received", job_id=job_id)
         elif cmd_type == "skip_field":

--- a/ghosthands/bridge/protocol.py
+++ b/ghosthands/bridge/protocol.py
@@ -20,6 +20,33 @@ import structlog
 
 logger = structlog.get_logger()
 
+_COMMAND_TYPES = frozenset(
+    {
+        "answer_field",
+        "skip_field",
+        "pause_job",
+        "resume_job",
+        "cancel",
+        "cancel_job",
+        "complete_review",
+    }
+)
+
+
+def parse_bridge_command(line: str) -> dict[str, Any] | None:
+    """Parse one supported JSON object from the VALET stdin channel."""
+    try:
+        command = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(command, dict) or command.get("type") not in _COMMAND_TYPES:
+        return None
+    if command["type"] in {"answer_field", "skip_field"} and not (
+        str(command.get("field_id") or "").strip() or str(command.get("field_label") or "").strip()
+    ):
+        return None
+    return command
+
 stdin_lock = asyncio.Lock()
 stdin_executor = concurrent.futures.ThreadPoolExecutor(
     max_workers=1,
@@ -98,6 +125,8 @@ _hitl_lock = asyncio.Lock()
 # get_field_answer() calls wake up immediately instead of blocking 300s.
 # Must be cleared at run start via reset_hitl_state().
 _cancel_event = asyncio.Event()
+_run_resume_event = asyncio.Event()
+_run_resume_event.set()
 
 
 _hitl_available = False  # Set True when listen_for_cancel starts (JSONL/Desktop mode)
@@ -109,11 +138,62 @@ def reset_hitl_state() -> None:
     Must be called at the start of each job to prevent cancel/answer
     leakage from previous runs in the same process.
     """
-    global _hitl_available
+    global _cancel_event, _hitl_available, _run_resume_event
     _pending_answers.clear()
     _answer_events.clear()
-    _cancel_event.clear()
+    _cancel_event = asyncio.Event()
+    _run_resume_event = asyncio.Event()
+    _run_resume_event.set()
     _hitl_available = False
+
+
+def activate_hitl() -> None:
+    """Mark stdin HITL active before the listener task is scheduled."""
+    global _hitl_available
+    _hitl_available = True
+
+
+async def wait_for_run_resume() -> bool:
+    """Wait at a browser-action boundary until resumed or cancelled."""
+    if _cancel_event.is_set():
+        return False
+    if not _hitl_available:
+        return True
+    await _run_resume_event.wait()
+    return not _cancel_event.is_set()
+
+
+def _pause_agent(agent: Any) -> None:
+    pause = getattr(agent, "pause", None)
+    if callable(pause):
+        pause()
+    agent.state.paused = True
+    pause_event = getattr(agent, "_external_pause_event", None)
+    if isinstance(pause_event, asyncio.Event):
+        pause_event.clear()
+    _run_resume_event.clear()
+
+
+def _resume_agent(agent: Any) -> None:
+    resume = getattr(agent, "resume", None)
+    if callable(resume):
+        resume()
+    agent.state.paused = False
+    pause_event = getattr(agent, "_external_pause_event", None)
+    if isinstance(pause_event, asyncio.Event):
+        pause_event.set()
+    _run_resume_event.set()
+
+
+def _stop_agent(agent: Any) -> None:
+    stop = getattr(agent, "stop", None)
+    if callable(stop):
+        stop()
+    agent.state.stopped = True
+    pause_event = getattr(agent, "_external_pause_event", None)
+    if isinstance(pause_event, asyncio.Event):
+        pause_event.set()
+    _run_resume_event.set()
 
 
 def is_hitl_available() -> bool:
@@ -236,9 +316,13 @@ async def get_field_answer(
 async def listen_for_cancel(
     agent: Any,  # noqa: ANN401
     cancel_requested: asyncio.Event | None = None,
+    *,
+    job_id: str = "",
 ) -> None:
     """Read stdin concurrently during agent run for cancel and answer commands."""
     global _hitl_available
+    from ghosthands.output.jsonl import emit_paused, emit_resumed, emit_run_state
+
     _hitl_available = True
     while not agent.state.stopped:
         try:
@@ -246,6 +330,7 @@ async def listen_for_cancel(
         except TimeoutError:
             continue
         except asyncio.CancelledError:
+            _hitl_available = False
             raise
         except Exception:
             await asyncio.sleep(0.1)
@@ -257,20 +342,15 @@ async def listen_for_cancel(
             _cancel_event.set()  # M13: wake any pending HITL waits
             if cancel_requested is not None:
                 cancel_requested.set()
-            agent.state.stopped = True
+            _stop_agent(agent)
             break
 
         line = line.strip()
         if not line:
             continue
 
-        try:
-            cmd = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-
-        # S-12: ignore valid JSON that isn't an object (e.g. [], "str", 1)
-        if not isinstance(cmd, dict):
+        cmd = parse_bridge_command(line)
+        if cmd is None:
             continue
 
         cmd_type = cmd.get("type")
@@ -279,8 +359,20 @@ async def listen_for_cancel(
             _cancel_event.set()  # M13: wake any pending HITL waits
             if cancel_requested is not None:
                 cancel_requested.set()
-            agent.state.stopped = True
+            _stop_agent(agent)
             break
+        elif cmd_type == "pause_job":
+            if not bool(getattr(agent.state, "paused", False)):
+                _pause_agent(agent)
+                target_id = getattr(getattr(agent, "browser_session", None), "agent_focus_target_id", None)
+                emit_paused(job_id=job_id, target_id=target_id)
+                emit_run_state("paused", job_id=job_id, target_id=target_id)
+        elif cmd_type == "resume_job":
+            if bool(getattr(agent.state, "paused", False)):
+                _resume_agent(agent)
+                target_id = getattr(getattr(agent, "browser_session", None), "agent_focus_target_id", None)
+                emit_resumed(job_id=job_id, target_id=target_id)
+                emit_run_state("running", job_id=job_id, target_id=target_id)
         elif cmd_type == "answer_field":
             field_id = cmd.get("field_id", "")
             field_label = cmd.get("field_label", "")
@@ -288,23 +380,28 @@ async def listen_for_cancel(
             key = field_id or field_label
             if key:
                 logger.info("answer_field_received", field_id=field_id, field_label=field_label)
-                put_field_answer(key, answer)
+                put_field_answer(field_id, answer, field_label=field_label)
+                if not bool(getattr(agent.state, "paused", False)):
+                    emit_run_state("running", message="Input received", job_id=job_id)
         elif cmd_type == "skip_field":
             field_id = cmd.get("field_id", "")
             field_label = cmd.get("field_label", "")
             key = field_id or field_label
             if key:
                 logger.info("skip_field_received", field_id=field_id, field_label=field_label)
-                put_field_answer(key, "")
+                put_field_answer(field_id, "", field_label=field_label)
+                if not bool(getattr(agent.state, "paused", False)):
+                    emit_run_state("running", message="Field skipped", job_id=job_id)
+    _hitl_available = False
 
 
 async def wait_for_review_command(browser: Any, job_id: str, lease_id: str) -> str:
     """Wait for a command from Electron on stdin.
 
     Expected commands:
-    - {"type": "complete_review"} -- user approved, close browser
-    - {"type": "cancel_job"}     -- user cancelled, close browser
-    - {"type": "cancel"}         -- user cancelled, close browser
+    - {"type": "complete_review"} -- user approved, detach engine
+    - {"type": "cancel_job"}     -- user cancelled, detach engine
+    - {"type": "cancel"}         -- user cancelled, detach engine
 
     Times out after 24 hours if no command is received.
 
@@ -316,7 +413,7 @@ async def wait_for_review_command(browser: Any, job_id: str, lease_id: str) -> s
     The CLI is responsible for emitting the terminal ``done`` event once
     this function returns a review outcome.
     """
-    from ghosthands.output.jsonl import emit_error, emit_status
+    from ghosthands.output.jsonl import emit_error, emit_paused, emit_resumed, emit_run_state, emit_status
 
     review_timeout_seconds = 24 * 60 * 60  # 24 hours — users may come back next day
     warning_before_seconds = 60 * 60  # Warn 1 hour before timeout.
@@ -331,7 +428,7 @@ async def wait_for_review_command(browser: Any, job_id: str, lease_id: str) -> s
 
             if not warning_emitted and remaining <= warning_before_seconds and remaining > 0:
                 emit_status(
-                    "Your review session will expire in about 1 hour. Please submit or cancel soon.",
+                    "Your review session will expire in about 1 hour. Please mark review complete or cancel soon.",
                     job_id=job_id,
                 )
                 warning_emitted = True
@@ -339,7 +436,7 @@ async def wait_for_review_command(browser: Any, job_id: str, lease_id: str) -> s
             if remaining <= 0:
                 logger.warning("review_timeout_exceeded", timeout_seconds=review_timeout_seconds)
                 emit_error(
-                    "Review session expired — please submit or cancel your application",
+                    "Review session expired; the engine detached and the browser tab remains open",
                     fatal=True,
                     job_id=job_id,
                 )
@@ -359,20 +456,15 @@ async def wait_for_review_command(browser: Any, job_id: str, lease_id: str) -> s
             if not line:
                 continue
 
-            try:
-                cmd = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            # S-12: ignore valid JSON that isn't an object (e.g. [], "str", 1)
-            if not isinstance(cmd, dict):
+            cmd = parse_bridge_command(line)
+            if cmd is None:
                 continue
 
             cmd_type = cmd.get("type", "")
 
             if cmd_type == "complete_review":
                 logger.info("review_completed", job_id=job_id, lease_id=lease_id)
-                emit_status("Review complete -- closing browser", job_id=job_id)
+                emit_status("Review complete -- detaching engine", job_id=job_id)
                 result = "complete"
                 break
             elif cmd_type in {"cancel", "cancel_job"}:
@@ -380,6 +472,14 @@ async def wait_for_review_command(browser: Any, job_id: str, lease_id: str) -> s
                 emit_status("Review cancelled by user", job_id=job_id)
                 result = "cancel"
                 break
+            elif cmd_type == "pause_job":
+                target_id = getattr(browser, "agent_focus_target_id", None)
+                emit_paused(job_id=job_id, target_id=target_id)
+                emit_run_state("paused", job_id=job_id, target_id=target_id)
+            elif cmd_type == "resume_job":
+                target_id = getattr(browser, "agent_focus_target_id", None)
+                emit_resumed(job_id=job_id, target_id=target_id)
+                emit_run_state("review_ready", job_id=job_id, target_id=target_id)
     except (EOFError, KeyboardInterrupt):
         pass
     finally:

--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -83,6 +83,41 @@ logger = structlog.get_logger()
 # If remaining budget is less than this, the agent stops before the next step.
 _STEP_COST_ESTIMATE = 0.10
 
+_REVIEW_SUCCESS_CLAIM_RE = re.compile(r"\b(?:submitted|applied)\b", re.IGNORECASE)
+_REVIEW_NEGATED_CLAIM_RE = re.compile(
+    r"(?:\b(?:not|never)\b|\bwithout(?:\s+being)?\b|\b(?:was|were|is|are|has|have|had|did)n't\b)"
+    r"(?:\s+\w+){0,3}\s*$",
+    re.IGNORECASE,
+)
+_REVIEW_CLAIM_REDACTION = "[forbidden final-submit success claim removed]"
+
+
+def _review_output_has_forbidden_success_claim(value: Any) -> bool:
+    """Return whether a review-only output value claims submit success."""
+    if isinstance(value, dict):
+        return any(_review_output_has_forbidden_success_claim(item) for item in value.values())
+    if isinstance(value, (list, tuple, set)):
+        return any(_review_output_has_forbidden_success_claim(item) for item in value)
+    if not isinstance(value, str):
+        return False
+    for match in _REVIEW_SUCCESS_CLAIM_RE.finditer(value):
+        if not _REVIEW_NEGATED_CLAIM_RE.search(value[max(0, match.start() - 64) : match.start()]):
+            return True
+    return False
+
+
+def _redact_review_success_claims(value: Any) -> Any:
+    """Remove prohibited success claims before a review-only payload is emitted."""
+    if isinstance(value, dict):
+        return {key: _redact_review_success_claims(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_review_success_claims(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_review_success_claims(item) for item in value)
+    if isinstance(value, str) and _review_output_has_forbidden_success_claim(value):
+        return _REVIEW_CLAIM_REDACTION
+    return value
+
 
 def _profile_debug_enabled() -> bool:
     return os.getenv("GH_DEBUG_PROFILE_PASS_THROUGH") == "1"
@@ -537,6 +572,9 @@ async def _run_workday_auth_preface(
 
     page = await browser_session.get_current_page()
     if page is None:
+        locked_target_id = str(getattr(browser_session, "_initial_target_id", "") or "")
+        if locked_target_id:
+            raise RuntimeError(f"Selected Chrome target {locked_target_id} is unavailable; refusing replacement tab")
         page = await browser_session.new_page(job_url)
     else:
         current = ""
@@ -2129,6 +2167,8 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
             cost_summary = summarize_history_cost(ag.history, ag.browser_session)
             last_cost_summary = cost_summary
             hist_payload = build_agent_history_payload(ag.history, sensitive_data)
+            if app_settings.submit_intent != "submit":
+                hist_payload = _redact_review_success_claims(hist_payload)
             jt.update_runtime_snapshot(
                 cost_summary,
                 step_count=max(n_hist, int(step)),
@@ -2137,6 +2177,8 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
         goal = ""
         if ag.state.last_model_output:
             goal = ag.state.last_model_output.next_goal or ""
+        if app_settings.submit_intent != "submit":
+            goal = _redact_review_success_claims(goal)
         phase = infer_phase_from_goal(goal)
         if phase:
             _emit_phase_if_changed(phase, detail=goal or None)
@@ -2206,6 +2248,8 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
         cost_summary = summarize_history_cost(ag.history, ag.browser_session)
         last_cost_summary = cost_summary
         hist_payload = build_agent_history_payload(ag.history, sensitive_data)
+        if app_settings.submit_intent != "submit":
+            hist_payload = _redact_review_success_claims(hist_payload)
         jt.update_runtime_snapshot(
             cost_summary,
             step_count=len(ag.history.history or []),
@@ -2507,6 +2551,9 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
                 **runtime_learning_payload,
             }
             cancel_rd["agentHistory"] = build_agent_history_payload(history, sensitive_data)
+            if app_settings.submit_intent != "submit" and _review_output_has_forbidden_success_claim(cancel_rd):
+                cancel_rd = _redact_review_success_claims(cancel_rd)
+                cancel_rd["blocker"] = "guard breach: final-submission confirmation detected in review mode"
             jt.emit_run_terminal(
                 termination_status="cancelled",
                 success=False,
@@ -2537,8 +2584,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
             if blocker is None:
                 blocker = final_result
         if app_settings.submit_intent != "submit" and final_result:
-            final_lower = final_result.lower()
-            if "application submitted" in final_lower or "submitted successfully" in final_lower:
+            if _review_output_has_forbidden_success_claim(final_result):
                 blocker = "guard breach: final-submission confirmation detected in review mode"
                 success = False
                 final_result = "Final-submission confirmation detected; review-only contract breached"
@@ -2571,6 +2617,14 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
             )
         result_data.update(runtime_learning_payload)
         result_data["agentHistory"] = build_agent_history_payload(history, sensitive_data)
+
+        if app_settings.submit_intent != "submit" and _review_output_has_forbidden_success_claim(result_data):
+            blocker = "guard breach: final-submission confirmation detected in review mode"
+            success = False
+            result_data = _redact_review_success_claims(result_data)
+            result_data["success"] = False
+            result_data["blocker"] = blocker
+            result_data["finalResult"] = "Final-submission confirmation detected; review-only contract breached"
 
         if success:
             # I-02/U-01: emit status (not done) before review so the terminal

--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -90,18 +90,62 @@ _REVIEW_NEGATED_CLAIM_RE = re.compile(
     re.IGNORECASE,
 )
 _REVIEW_CLAIM_REDACTION = "[forbidden final-submit success claim removed]"
+_REVIEW_INTERNAL_NONFINAL_FORM_RE = re.compile(
+    r"\bsubmitted\s+form\s+for\s+(['\"])(?P<label>[^'\"]+)\1",
+    re.IGNORECASE,
+)
+_REVIEW_PROVEN_NONFINAL_FORM_LABELS = {
+    "next",
+    "continue",
+    "save",
+    "save and continue",
+    "save & continue",
+    "continue to review",
+}
+
+
+def _review_key_tokens(key: Any) -> set[str]:
+    text = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", str(key or ""))
+    return set(re.sub(r"[^a-zA-Z0-9]+", " ", text).lower().split())
+
+
+def _review_key_value_claims_success(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return value > 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return normalized not in {"", "0", "false", "no", "none", "null", "not submitted", "not applied"}
+    return value is not None and bool(value)
+
+
+def _review_key_reports_success(key: Any, value: Any) -> bool:
+    return bool(_review_key_tokens(key) & {"submitted", "applied"}) and _review_key_value_claims_success(value)
+
+
+def _strip_proven_internal_navigation_claims(value: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        label = re.sub(r"\s+", " ", match.group("label")).strip().lower()
+        return "advanced form" if label in _REVIEW_PROVEN_NONFINAL_FORM_LABELS else match.group(0)
+
+    return _REVIEW_INTERNAL_NONFINAL_FORM_RE.sub(replace, value)
 
 
 def _review_output_has_forbidden_success_claim(value: Any) -> bool:
     """Return whether a review-only output value claims submit success."""
     if isinstance(value, dict):
-        return any(_review_output_has_forbidden_success_claim(item) for item in value.values())
+        return any(
+            _review_key_reports_success(key, item) or _review_output_has_forbidden_success_claim(item)
+            for key, item in value.items()
+        )
     if isinstance(value, (list, tuple, set)):
         return any(_review_output_has_forbidden_success_claim(item) for item in value)
     if not isinstance(value, str):
         return False
-    for match in _REVIEW_SUCCESS_CLAIM_RE.finditer(value):
-        if not _REVIEW_NEGATED_CLAIM_RE.search(value[max(0, match.start() - 64) : match.start()]):
+    checked_value = _strip_proven_internal_navigation_claims(value)
+    for match in _REVIEW_SUCCESS_CLAIM_RE.finditer(checked_value):
+        if not _REVIEW_NEGATED_CLAIM_RE.search(checked_value[max(0, match.start() - 64) : match.start()]):
             return True
     return False
 
@@ -109,7 +153,14 @@ def _review_output_has_forbidden_success_claim(value: Any) -> bool:
 def _redact_review_success_claims(value: Any) -> Any:
     """Remove prohibited success claims before a review-only payload is emitted."""
     if isinstance(value, dict):
-        return {key: _redact_review_success_claims(item) for key, item in value.items()}
+        redacted = {
+            key: _redact_review_success_claims(item)
+            for key, item in value.items()
+            if not (_review_key_tokens(key) & {"submitted", "applied"})
+        }
+        if len(redacted) != len(value):
+            redacted["finalSubmitClaimRemoved"] = True
+        return redacted
     if isinstance(value, list):
         return [_redact_review_success_claims(item) for item in value]
     if isinstance(value, tuple):

--- a/ghosthands/cli.py
+++ b/ghosthands/cli.py
@@ -53,6 +53,7 @@ from ghosthands.bridge.profile_adapter import (
     normalize_profile_defaults,
 )
 from ghosthands.bridge.protocol import (
+    activate_hitl,
     listen_for_cancel,
     reset_hitl_state,
     wait_for_review_command,
@@ -698,6 +699,12 @@ def parse_args() -> argparse.Namespace:
         help="Connect to an existing browser via CDP URL instead of launching a new one (Desktop-owned browser mode)",
     )
     parser.add_argument(
+        "--cdp-target-id",
+        type=str,
+        default=None,
+        help="Exact Chrome target/tab ID to use with --cdp-url (or GH_TARGET_ID)",
+    )
+    parser.add_argument(
         "--engine",
         choices=["auto", "chromium", "firefox"],
         default="auto",
@@ -707,6 +714,12 @@ def parse_args() -> argparse.Namespace:
     args = parser.parse_args(argv)
     if args.output_format != "tui" and not args.job_url:
         parser.error("the following arguments are required: --job-url")
+    if args.output_format == "tui" and args.submit_intent == "submit":
+        parser.error("the bundled terminal UI supports review intent only")
+    resolved_cdp_url = args.cdp_url or os.environ.get("GH_CDP_URL")
+    resolved_target_id = args.cdp_target_id or os.environ.get("GH_TARGET_ID")
+    if bool(resolved_cdp_url) != bool(resolved_target_id):
+        parser.error("--cdp-url and --cdp-target-id must be provided together")
     return args
 
 
@@ -1121,22 +1134,18 @@ async def _cleanup_browser(
 ) -> None:
     """Shut down the browser session with ownership-aware cleanup.
 
-    When the Desktop app owns the browser (CDP mode), we only disconnect
-    from the session via ``stop()`` — the browser process stays alive for
-    the Desktop app to manage.
+    When the Desktop app owns the browser (CDP mode), detach the CDP client
+    without dispatching browser or tab lifecycle events.
 
     When Hand-X launched the browser itself, Desktop/local-worker JSONL mode
     now leaves the browser entirely untouched so the user can keep inspecting
     the failed page. Only standalone human-mode runs should kill it here.
     """
-    if keep_browser_alive:
+    if desktop_owns_browser or keep_browser_alive:
         logger.info("browser.cleanup_detaching_keep_alive")
         await browser.detach_keep_alive()
         return
-    if desktop_owns_browser:
-        await browser.stop()
-    else:
-        await browser.kill()
+    await browser.kill()
 
 
 @dataclass(frozen=True)
@@ -1753,9 +1762,9 @@ def _handle_review_result(
 
     if review_result == "complete":
         emit_run_terminal(
-            termination_status="completed",
+            termination_status="review_complete",
             success=True,
-            message="Application submitted — review completed",
+            message="Review complete; engine detached",
             fields_filled=fields_filled,
             fields_failed=fields_failed,
             job_id=job_id,
@@ -1785,7 +1794,7 @@ def _handle_review_result(
         emit_run_terminal(
             termination_status="review_timeout",
             success=False,
-            message="Review timed out after 30 minutes. The browser window is still open — you can submit manually.",
+            message="Review timed out; the browser tab remains open and the engine detached.",
             fields_filled=fields_filled,
             fields_failed=fields_failed,
             job_id=job_id,
@@ -1869,6 +1878,8 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
         emit_cost,
         emit_error,
         emit_phase,
+        emit_review_ready,
+        emit_run_state,
         emit_status,
     )
 
@@ -1888,6 +1899,7 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
     keep_worker_browser_alive = args.output_format == "jsonl"
     last_phase: str | None = None
     account_created_emitted = False
+    emit_run_state("starting")
 
     def _emit_phase_if_changed(phase: str, detail: str | None = None) -> None:
         nonlocal last_phase
@@ -2045,13 +2057,15 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
 
     # -- Browser ------------------------------------------------------------
     cdp_url = args.cdp_url or os.environ.get("GH_CDP_URL")
-    cdp_target_id = os.environ.get("GH_TARGET_ID")
+    cdp_target_id = getattr(args, "cdp_target_id", None) or os.environ.get("GH_TARGET_ID")
+    if bool(cdp_url) != bool(cdp_target_id):
+        raise ValueError("--cdp-url and --cdp-target-id must be provided together")
     desktop_owns_browser = cdp_url is not None
 
     if cdp_url:
         # Desktop-owned browser: connect to existing browser via CDP URL.
         # Do not launch a new browser; the browser is always headful (visible to user).
-        # If GH_TARGET_ID is set, attach to that specific tab (shared-browser mode).
+        # Attach to the exact target selected by the VALET host.
         # Explicit headless=False + no_viewport=True prevents detect_display_configuration()
         # from incorrectly assuming headless mode (get_display_size() returns None in
         # Electron-spawned subprocesses) and setting a 1920x1080 viewport override via CDP,
@@ -2316,8 +2330,14 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
             )
             sys.exit(1)
         logger.warning("startup.browser_ready", cdp_url=bool(browser.cdp_url))
+        active_target_id = str(getattr(browser, "agent_focus_target_id", None) or "")
+        if cdp_target_id and active_target_id != cdp_target_id:
+            raise RuntimeError(
+                f"Browser attached to target {active_target_id or '<none>'}, expected {cdp_target_id}"
+            )
         if browser.cdp_url:
-            emit_browser_ready(browser.cdp_url)
+            emit_browser_ready(browser.cdp_url, target_id=active_target_id)
+            emit_run_state("running", job_id=job_id, target_id=active_target_id)
         else:
             logger.warning("cli.browser_ready_missing_cdp_url")
             emit_status(
@@ -2381,9 +2401,17 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
                 directly_open_url=directly_open_url,
             )
 
+            await install_same_tab_guard(agent)
+            await install_final_submit_guard(
+                agent,
+                allow_submit=app_settings.submit_intent == "submit",
+            )
             reset_hitl_state()
+            activate_hitl()
             cancel_requested = asyncio.Event()
-            cancel_task = asyncio.create_task(listen_for_cancel(agent, cancel_requested))
+            cancel_task = asyncio.create_task(
+                listen_for_cancel(agent, cancel_requested, job_id=job_id)
+            )
             try:
                 _emit_phase_if_changed("Navigating to application")
                 logger.warning("startup.agent_run_starting", max_steps=args.max_steps)
@@ -2511,8 +2539,9 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
         if app_settings.submit_intent != "submit" and final_result:
             final_lower = final_result.lower()
             if "application submitted" in final_lower or "submitted successfully" in final_lower:
-                blocker = "guard breach: application was submitted despite submit_intent=review"
+                blocker = "guard breach: final-submission confirmation detected in review mode"
                 success = False
+                final_result = "Final-submission confirmation detected; review-only contract breached"
 
         result_data = {
             "success": success,
@@ -2567,8 +2596,35 @@ async def run_agent_jsonl(args: argparse.Namespace) -> None:
             with contextlib.suppress(Exception):
                 review_page_url = await browser.get_current_page_url()
 
+            emit_review_ready(
+                cdp_url=review_cdp_url or "",
+                target_id=active_target_id,
+                page_url=review_page_url,
+                cost_summary=cost_summary,
+            )
+            if desktop_owns_browser:
+                jt.emit_run_terminal(
+                    termination_status="review_ready",
+                    success=True,
+                    message="Application ready for review; engine detached",
+                    fields_filled=filled_count,
+                    fields_failed=failed_count,
+                    job_id=job_id,
+                    lease_id=lease_id,
+                    result_data=result_data,
+                    cost_summary=cost_summary,
+                    total_cost_usd=total_cost,
+                )
+                await _cleanup_browser(
+                    browser,
+                    desktop_owns_browser,
+                    keep_browser_alive=True,
+                )
+                return
+
             emit_awaiting_review(
                 cdp_url=review_cdp_url,
+                target_id=active_target_id,
                 page_url=review_page_url,
             )
             review_result = await wait_for_review_command(browser, job_id, lease_id)
@@ -2825,6 +2881,9 @@ async def run_agent_human(args: argparse.Namespace) -> None:
 
     # -- Browser ------------------------------------------------------------
     cdp_url = args.cdp_url or os.environ.get("GH_CDP_URL")
+    cdp_target_id = getattr(args, "cdp_target_id", None) or os.environ.get("GH_TARGET_ID")
+    if bool(cdp_url) != bool(cdp_target_id):
+        raise ValueError("--cdp-url and --cdp-target-id must be provided together")
     desktop_owns_browser = cdp_url is not None
 
     if cdp_url:
@@ -2833,8 +2892,12 @@ async def run_agent_human(args: argparse.Namespace) -> None:
         browser_profile = BrowserProfile(
             keep_alive=True, allowed_domains=allowed_domains, headless=False, no_viewport=True
         )
-        browser = BrowserSession(browser_profile=browser_profile, cdp_url=cdp_url)
-        print(f"Connecting to Desktop-owned browser via CDP: {cdp_url}")
+        browser = BrowserSession(
+            browser_profile=browser_profile,
+            cdp_url=cdp_url,
+            target_id=cdp_target_id,
+        )
+        print(f"Connecting to Desktop-owned browser target {cdp_target_id} via CDP: {cdp_url}")
     else:
         browser_profile = BrowserProfile(
             headless=args.headless,
@@ -2875,6 +2938,10 @@ async def run_agent_human(args: argparse.Namespace) -> None:
 
     print("Starting browser...")
     await asyncio.wait_for(browser.start(), timeout=60)
+    if cdp_target_id and browser.agent_focus_target_id != cdp_target_id:
+        raise RuntimeError(
+            f"Browser attached to target {browser.agent_focus_target_id or '<none>'}, expected {cdp_target_id}"
+        )
 
     workday_preface_status = "noop"
     workday_preface_message = ""
@@ -2956,6 +3023,11 @@ async def run_agent_human(args: argparse.Namespace) -> None:
                 ]
 
     try:
+        await install_same_tab_guard(agent)
+        await install_final_submit_guard(
+            agent,
+            allow_submit=app_settings.submit_intent == "submit",
+        )
         history = await agent.run(
             max_steps=args.max_steps,
             on_step_start=_on_step_start_human,

--- a/ghosthands/dom/fill_browser_scripts.py
+++ b/ghosthands/dom/fill_browser_scripts.py
@@ -765,13 +765,43 @@ _CLICK_SINGLE_RADIO_JS = r"""(ffId, text) => {
 	return JSON.stringify({clicked: false});
 }"""
 
-_CLICK_CHECKBOX_GROUP_JS = r"""(ffId) => {
+_CLICK_CHECKBOX_GROUP_JS = r"""(ffId, desiredValue) => {
 	var ff = window.__ff;
 	var el = ff ? ff.byId(ffId) : null;
 	if (!el) return JSON.stringify({clicked: false});
 	var group = ff.closestCrossRoot(el, '.checkbox-group, [role="group"]') || el;
 	var cbs = Array.from(group.querySelectorAll('input[type="checkbox"], [role="checkbox"]'));
 	if (cbs.length === 0) return JSON.stringify({clicked: false});
+	var normalize = function(s) { return (s || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim(); };
+	var requested = String(desiredValue || '').split(',').map(normalize).filter(Boolean);
+	var booleanRequest = requested.length === 1 && ['true', 'checked', 'yes', 'on', '1'].includes(requested[0]);
+	if (requested.length && !booleanRequest) {
+		var getLabel = function(cb) {
+			var aria = cb.getAttribute('aria-label');
+			if (aria && aria.trim()) return aria.trim();
+			if (cb.id) {
+				var linked = ff.queryOne('label[for="' + CSS.escape(cb.id) + '"]');
+				if (linked) return linked.textContent || '';
+			}
+			var wrapped = cb.closest('label');
+			return wrapped ? wrapped.textContent || '' : cb.value || '';
+		};
+		var controls = new Map();
+		for (var r = 0; r < requested.length; r++) {
+			for (var c = 0; c < cbs.length; c++) {
+				var labels = [normalize(getLabel(cbs[c])), normalize(cbs[c].value)];
+				if (labels.includes(requested[r])) { controls.set(requested[r], cbs[c]); break; }
+			}
+		}
+		if (controls.size !== requested.length) return JSON.stringify({clicked: false, matchedCount: controls.size});
+		var selected = new Set(Array.from(controls.values()));
+		var changed = 0;
+		for (var j = 0; j < cbs.length; j++) {
+			var checked = cbs[j].checked || cbs[j].getAttribute('aria-checked') === 'true';
+			if (checked !== selected.has(cbs[j])) { cbs[j].click(); changed += 1; }
+		}
+		return JSON.stringify({clicked: true, alreadyChecked: changed === 0, matchedCount: controls.size});
+	}
 	for (var i = 0; i < cbs.length; i++) {
 		if (cbs[i].checked || cbs[i].getAttribute('aria-checked') === 'true') return JSON.stringify({clicked: true, alreadyChecked: true});
 	}

--- a/ghosthands/dom/fill_executor.py
+++ b/ghosthands/dom/fill_executor.py
@@ -5273,9 +5273,12 @@ async def _fill_checkbox_group(page: Any, field: FormField, value: str, tag: str
                     )
                     return True
         try:
-            result_json = await page.evaluate(_CLICK_CHECKBOX_GROUP_JS, field.field_id)
+            result_json = await page.evaluate(_CLICK_CHECKBOX_GROUP_JS, field.field_id, value)
             result = json.loads(result_json)
             if result.get("clicked"):
+                if result.get("matchedCount") and not await _field_has_validation_error(page, field.field_id):
+                    logger.debug(f'check {tag} -> "{value}"')
+                    return True
                 current = await _read_binary_state(page, field.field_id)
                 if result.get("alreadyChecked") and not await _field_has_validation_error(page, field.field_id):
                     logger.debug(f"skip {tag} (already checked)")

--- a/ghosthands/dom/fill_label_match.py
+++ b/ghosthands/dom/fill_label_match.py
@@ -489,6 +489,14 @@ def _coerce_answer_to_field(field: FormField, answer: str | None) -> str | None:
         for candidate in _field_label_candidates(field)
     )
     degree_family_answer = _normalize_degree_family_answer(text) if degree_like_label else None
+    choices = [str(choice).strip() for choice in (field.options or field.choices or []) if str(choice).strip()]
+    if field.field_type == "checkbox-group" and "," in text and choices:
+        requested = [part.strip() for part in text.split(",") if part.strip()]
+        choices_by_name = {normalize_name(choice): choice for choice in choices}
+        matched = [choices_by_name.get(normalize_name(part)) for part in requested]
+        if requested and all(matched):
+            return ", ".join(str(choice) for choice in matched)
+        return None
 
     # Workday skills/selectinput widgets intentionally accept comma-joined
     # multi-value answers and split them later inside ``_fill_multi_select``.
@@ -513,7 +521,6 @@ def _coerce_answer_to_field(field: FormField, answer: str | None) -> str | None:
         for candidate in _field_label_candidates(field)
     )
 
-    choices = [str(choice).strip() for choice in (field.options or field.choices or []) if str(choice).strip()]
     if not choices:
         if field.field_type == "select" and latest_employer_label:
             return None

--- a/ghosthands/output/jsonl.py
+++ b/ghosthands/output/jsonl.py
@@ -14,6 +14,7 @@ library imports to capture the real stdout fd.  After installation:
 from __future__ import annotations
 
 import json
+import math
 import sys
 import threading
 import time
@@ -58,10 +59,40 @@ def _get_output() -> IO[str]:
 
 # ── Core emitter ──────────────────────────────────────────────────────
 _emit_lock = threading.Lock()
+_state_lock = threading.Lock()
 _pipe_broken = False
+_event_version = 0
+_last_timestamp_ms = 0
+_run_status = "running"
+_max_total_usd = 0.0
+_max_prompt_tokens = 0
+_max_completion_tokens = 0
 
-_emit_lock = threading.Lock()
-_pipe_broken = False
+
+def _set_run_status(status: str) -> None:
+    global _run_status
+    with _state_lock:
+        _run_status = status
+
+
+def _get_run_status() -> str:
+    with _state_lock:
+        return _run_status
+
+
+def reset_event_state() -> None:
+    """Reset per-process ordering and cumulative cost state before a run."""
+    global _event_version, _last_timestamp_ms, _max_completion_tokens
+    global _max_prompt_tokens, _max_total_usd, _pipe_broken, _run_status
+    with _emit_lock:
+        _event_version = 0
+        _last_timestamp_ms = 0
+        _pipe_broken = False
+    with _state_lock:
+        _run_status = "running"
+        _max_total_usd = 0.0
+        _max_prompt_tokens = 0
+        _max_completion_tokens = 0
 
 
 def emit_event(event_type: str, **kwargs: Any) -> None:
@@ -71,7 +102,7 @@ def emit_event(event_type: str, **kwargs: Any) -> None:
     passed through as keyword arguments -- ``None`` values are omitted
     to keep the wire format compact.
     """
-    global _pipe_broken
+    global _event_version, _last_timestamp_ms, _pipe_broken
     if _pipe_broken:
         if event_type in ("done", "error"):
             print(
@@ -80,16 +111,23 @@ def emit_event(event_type: str, **kwargs: Any) -> None:
             )
         return
 
-    event: dict[str, Any] = {
-        "event": event_type,
-        "timestamp": int(time.time() * 1000),
-    }
-    for key, value in kwargs.items():
-        if value is not None:
-            event[key] = value
-
-    line = json.dumps(event, separators=(",", ":")) + "\n"
     with _emit_lock:
+        _event_version += 1
+        _last_timestamp_ms = max(_last_timestamp_ms + 1, int(time.time() * 1000))
+        event: dict[str, Any] = {
+            "type": event_type,
+            "event": event_type,
+            "version": _event_version,
+            "sequence": _event_version,
+            "timestamp": _last_timestamp_ms,
+        }
+        for key, value in kwargs.items():
+            if key in {"type", "event", "version", "sequence", "timestamp"}:
+                continue
+            if value is not None:
+                event[key] = value
+
+        line = json.dumps(event, separators=(",", ":")) + "\n"
         try:
             out = _get_output()
             out.write(line)
@@ -113,6 +151,7 @@ def emit_status(
     emit_event(
         "status",
         message=message,
+        status=_get_run_status(),
         step=step,
         maxSteps=max_steps,
         jobId=job_id or None,
@@ -121,7 +160,7 @@ def emit_status(
 
 def emit_phase(phase: str, detail: str | None = None) -> None:
     """Emit a high-level progress phase for user display."""
-    emit_event("phase", phase=phase, detail=detail)
+    emit_event("phase", status=_get_run_status(), phase=phase, detail=detail)
 
 
 def emit_field_filled(
@@ -141,6 +180,7 @@ def emit_field_filled(
     """Emit after a form field is successfully filled."""
     emit_event(
         "field_filled",
+        status=_get_run_status(),
         field=field,
         value=value,
         method=method,
@@ -160,7 +200,7 @@ def emit_field_failed(
     reason: str,
 ) -> None:
     """Emit when a field fill attempt fails."""
-    emit_event("field_failed", field=field, reason=reason)
+    emit_event("field_failed", status=_get_run_status(), field=field, reason=reason)
 
 
 def emit_progress(
@@ -170,7 +210,13 @@ def emit_progress(
     description: str = "",
 ) -> None:
     """Emit a progress snapshot."""
-    emit_event("progress", step=step, maxSteps=max_steps, description=description)
+    emit_event(
+        "progress",
+        status=_get_run_status(),
+        step=step,
+        maxSteps=max_steps,
+        description=description,
+    )
 
 
 def emit_done(
@@ -186,6 +232,7 @@ def emit_done(
     """Emit when the job is complete (success or failure)."""
     emit_event(
         "done",
+        status=_get_run_status(),
         success=success,
         message=message,
         fields_filled=fields_filled,
@@ -221,18 +268,174 @@ def emit_cost(
     cost_summary: dict[str, Any] | None = None,
 ) -> None:
     """Emit a cost snapshot (cumulative LLM spend)."""
+    global _max_completion_tokens, _max_prompt_tokens, _max_total_usd
+    with _state_lock:
+        _max_total_usd = max(_max_total_usd, float(total_usd or 0.0))
+        _max_prompt_tokens = max(_max_prompt_tokens, int(prompt_tokens or 0))
+        _max_completion_tokens = max(_max_completion_tokens, int(completion_tokens or 0))
+        cumulative_usd = round(_max_total_usd, 6)
+        cumulative_prompt_tokens = _max_prompt_tokens
+        cumulative_completion_tokens = _max_completion_tokens
+
+    summary = dict(cost_summary or {})
+    summary["actualCostCents"] = max(
+        int(summary.get("actualCostCents") or 0),
+        math.ceil(cumulative_usd * 100),
+    )
+    summary["total_tracked_cost_usd"] = max(
+        float(summary.get("total_tracked_cost_usd") or 0.0),
+        cumulative_usd,
+    )
     emit_event(
         "cost",
-        total_usd=round(total_usd, 6),
-        prompt_tokens=prompt_tokens,
-        completion_tokens=completion_tokens,
-        cost_summary=cost_summary,
+        status=_get_run_status(),
+        total_usd=cumulative_usd,
+        prompt_tokens=cumulative_prompt_tokens,
+        completion_tokens=cumulative_completion_tokens,
+        cost_summary=summary,
+        costSummary=summary,
     )
 
 
-def emit_browser_ready(cdp_url: str) -> None:
-    """Emit browser_ready event with CDP WebSocket URL."""
-    emit_event("browser_ready", cdpUrl=cdp_url)
+def emit_browser_ready(
+    cdp_url: str,
+    *,
+    target_id: str | None = None,
+    page_url: str | None = None,
+) -> None:
+    """Emit the browser endpoint and exact target selected for this run."""
+    emit_event(
+        "browser_ready",
+        status=_get_run_status(),
+        cdpUrl=cdp_url,
+        targetId=target_id,
+        pageUrl=page_url,
+    )
+
+
+def emit_run_state(
+    state: str,
+    *,
+    message: str | None = None,
+    job_id: str = "",
+    target_id: str | None = None,
+) -> None:
+    """Emit an explicit VALET run-state transition."""
+    status = {
+        "paused": "waiting_human",
+        "waiting_human": "waiting_human",
+        "review_ready": "review_ready",
+        "cancelled": "cancelled",
+        "budget_reached": "budget_reached",
+        "failed_retryable": "failed_retryable",
+        "failed_terminal": "failed_terminal",
+    }.get(state, "running")
+    _set_run_status(status)
+    emit_event(
+        "run_state",
+        status=status,
+        state=state,
+        message=message,
+        jobId=job_id or None,
+        targetId=target_id,
+    )
+
+
+def emit_paused(*, job_id: str = "", target_id: str | None = None) -> None:
+    """Emit the acknowledgement for ``pause_job``."""
+    _set_run_status("waiting_human")
+    emit_event(
+        "paused",
+        status="waiting_human",
+        state="paused",
+        paused=True,
+        jobId=job_id or None,
+        targetId=target_id,
+    )
+
+
+def emit_resumed(*, job_id: str = "", target_id: str | None = None) -> None:
+    """Emit the acknowledgement for ``resume_job``."""
+    _set_run_status("running")
+    emit_event(
+        "resumed",
+        status="running",
+        state="running",
+        paused=False,
+        jobId=job_id or None,
+        targetId=target_id,
+    )
+
+
+def emit_needs_answer(
+    *,
+    field_id: str,
+    label: str,
+    field_type: str,
+    options: list[str],
+    required: bool,
+    section: str,
+    job_id: str = "",
+) -> None:
+    """Emit one Go-compatible HITL question."""
+    question = {
+        "fieldId": field_id,
+        "fieldLabel": label,
+        "fieldType": field_type,
+        "options": list(options),
+        "required": bool(required),
+        "section": section,
+    }
+    _set_run_status("waiting_human")
+    emit_event(
+        "needs_answer",
+        status="waiting_human",
+        message=f"Input required: {label}",
+        jobId=job_id or None,
+        waiting_human=True,
+        questions=[question],
+        field={
+            "id": field_id,
+            "label": label,
+            "type": field_type,
+            "options": list(options),
+            "required": bool(required),
+            "section": section,
+        },
+    )
+
+
+def emit_review_ready(
+    *,
+    cdp_url: str,
+    target_id: str,
+    page_url: str | None = None,
+    message: str = "Application ready for review",
+    cost_summary: dict[str, Any] | None = None,
+) -> None:
+    """Emit the terminal presubmit checkpoint without claiming submission."""
+    if not cdp_url.strip():
+        raise ValueError("review_ready requires an explicit cdp_url")
+    if not target_id.strip():
+        raise ValueError("review_ready requires an explicit target_id")
+    summary = dict(cost_summary or {})
+    if summary:
+        total_usd = float(summary.get("total_tracked_cost_usd") or 0.0)
+        summary["actualCostCents"] = max(
+            int(summary.get("actualCostCents") or 0),
+            math.ceil(total_usd * 100),
+        )
+    _set_run_status("review_ready")
+    emit_event(
+        "review_ready",
+        status="review_ready",
+        message=message,
+        cdpUrl=cdp_url,
+        targetId=target_id,
+        pageUrl=page_url,
+        review_ready=True,
+        costSummary=summary or None,
+    )
 
 
 def emit_account_created(
@@ -269,13 +472,22 @@ def emit_account_created(
 def emit_awaiting_review(
     message: str = (
         "We've filled out your application. Please review the form in the browser "
-        "window, verify all fields are correct, then click Submit in the app."
+        "window, verify all fields are correct, then mark review complete."
     ),
     cdp_url: str | None = None,
+    target_id: str | None = None,
     page_url: str | None = None,
 ) -> None:
     """Emit awaiting_review event when browser is open for user review."""
-    emit_event("awaiting_review", message=message, cdpUrl=cdp_url, pageUrl=page_url)
+    _set_run_status("review_ready")
+    emit_event(
+        "awaiting_review",
+        status="review_ready",
+        message=message,
+        cdpUrl=cdp_url,
+        targetId=target_id,
+        pageUrl=page_url,
+    )
 
 
 # ── Protocol handshake ───────────────────────────────────────────────
@@ -285,6 +497,7 @@ PROTOCOL_VERSION = 1
 
 def emit_handshake() -> None:
     """Emit protocol version handshake as the first JSONL event."""
+    reset_event_state()
     emit_event("handshake", protocol_version=PROTOCOL_VERSION, min_desktop_version="0.1.0")
 
 

--- a/ghosthands/output/jsonl.py
+++ b/ghosthands/output/jsonl.py
@@ -378,10 +378,17 @@ def emit_needs_answer(
     job_id: str = "",
 ) -> None:
     """Emit one Go-compatible HITL question."""
+    normalized_type = str(field_type or "text").strip().lower().replace("_", "-")
+    if normalized_type in {"select", "choice", "radio", "radio-group", "button-group"}:
+        normalized_type = "choice"
+    elif normalized_type in {"checkbox", "checkboxes", "checkbox-group", "multi-select"}:
+        normalized_type = "checkbox"
+    else:
+        normalized_type = "text"
     question = {
         "fieldId": field_id,
         "fieldLabel": label,
-        "fieldType": field_type,
+        "fieldType": normalized_type,
         "options": list(options),
         "required": bool(required),
         "section": section,
@@ -397,7 +404,7 @@ def emit_needs_answer(
         field={
             "id": field_id,
             "label": label,
-            "type": field_type,
+            "type": normalized_type,
             "options": list(options),
             "required": bool(required),
             "section": section,

--- a/ghosthands/tui.py
+++ b/ghosthands/tui.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 from rich.console import Console, Group
 from rich.live import Live
 from rich.panel import Panel
@@ -29,6 +29,13 @@ class TuiEvent(BaseModel):
 
     event: str
     timestamp: int | float | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_event_name(cls, value: Any) -> Any:
+        if isinstance(value, dict) and not value.get("event") and value.get("type"):
+            value = {**value, "event": value["type"]}
+        return value
 
     @property
     def data(self) -> dict[str, Any]:
@@ -56,6 +63,8 @@ class TuiRunState:
     lease_id: str = ""
     sync_status: str = "Local run"
     awaiting_review: bool = False
+    review_ready: bool = False
+    pending_question: dict[str, Any] | None = None
     done: bool = False
     success: bool | None = None
     message: str = ""
@@ -127,6 +136,36 @@ class TuiRunState:
             self.cdp_url = str(data.get("cdpUrl") or "")
             self.status = "Browser ready"
             self.add_log("browser", "Browser ready for automation")
+            return
+
+        if kind == "needs_answer":
+            questions = data.get("questions")
+            question = questions[0] if isinstance(questions, list) and questions else data.get("field")
+            if isinstance(question, dict):
+                self.pending_question = question
+                self.phase = "Input required"
+                label = str(question.get("fieldLabel") or question.get("label") or "Field input")
+                self.status = str(data.get("message") or label)
+                self.add_log("input", label)
+            return
+
+        if kind == "paused":
+            self.status = str(data.get("message") or "Paused")
+            self.add_log("control", self.status)
+            return
+
+        if kind == "resumed":
+            self.status = str(data.get("message") or "Resumed")
+            self.add_log("control", self.status)
+            return
+
+        if kind == "review_ready":
+            self.review_ready = True
+            self.phase = "Review"
+            self.status = str(data.get("message") or "Application ready for review")
+            self.cdp_url = str(data.get("cdpUrl") or self.cdp_url)
+            self.page_url = str(data.get("pageUrl") or self.page_url)
+            self.add_log("review", self.status)
             return
 
         if kind == "account_created":
@@ -221,12 +260,13 @@ def build_engine_argv(args: argparse.Namespace, executable: Sequence[str] | None
     add_option("--model", args.model)
     add_option("--max-steps", args.max_steps)
     add_option("--max-budget", args.max_budget)
-    add_option("--submit-intent", args.submit_intent)
+    add_option("--submit-intent", "review")
     add_option("--proxy-url", args.proxy_url)
     add_option("--runtime-grant", args.runtime_grant)
     add_option("--allowed-domains", args.allowed_domains)
     add_option("--browsers-path", args.browsers_path)
     add_option("--cdp-url", args.cdp_url)
+    add_option("--cdp-target-id", getattr(args, "cdp_target_id", None))
     add_option("--engine", getattr(args, "engine", None))
     if args.headless:
         argv.append("--headless")
@@ -265,9 +305,17 @@ async def run_tui(args: argparse.Namespace) -> None:
     try:
         while proc.returncode is None:
             with Live(_render_state(state), console=console, refresh_per_second=4) as live:
-                while proc.returncode is None and not (state.awaiting_review and not review_command_sent):
+                while proc.returncode is None and not (
+                    state.pending_question or (state.awaiting_review and not review_command_sent)
+                ):
                     live.update(_render_state(state))
                     await asyncio.sleep(0.25)
+
+            if state.pending_question:
+                await _handle_hitl_prompt(proc, state, console)
+                state.pending_question = None
+                state.status = "Input sent; automation resuming"
+                continue
 
             if state.awaiting_review and not review_command_sent:
                 await _handle_review_prompt(proc, state, console)
@@ -305,8 +353,9 @@ def _collect_tui_args(args: argparse.Namespace, console: Console) -> argparse.Na
     if (missing_core or not has_profile_source) and not sys.stdin.isatty():
         raise SystemExit("TUI mode needs an interactive terminal when job/profile inputs are missing.")
 
+    values["submit_intent"] = "review"
+
     if not sys.stdin.isatty():
-        values["submit_intent"] = values.get("submit_intent") or "review"
         values["output_format"] = "tui"
         return argparse.Namespace(**values)
 
@@ -342,9 +391,6 @@ def _collect_tui_args(args: argparse.Namespace, console: Console) -> argparse.Na
     values["max_budget"] = float(Prompt.ask("Max budget USD", default=str(values.get("max_budget") or 0.5)))
     values["headless"] = Confirm.ask("Run browser headless?", default=bool(values.get("headless")))
 
-    if not values.get("submit_intent"):
-        values["submit_intent"] = Prompt.ask("Final submit mode", choices=["review", "submit"], default="review")
-
     _validate_path(values.get("resume"), "Resume")
     if values.get("profile") and str(values["profile"]).startswith("@"):
         _validate_path(str(values["profile"])[1:], "Profile")
@@ -366,7 +412,7 @@ def _intro_panel(args: argparse.Namespace) -> Panel:
     table.add_row("Job", str(args.job_url))
     table.add_row("Profile", _profile_source_label(args))
     table.add_row("Resume", str(args.resume or "none"))
-    table.add_row("Mode", str(args.submit_intent or "review"))
+    table.add_row("Mode", "review")
     table.add_row("Browser", "headless" if args.headless else "visible")
     table.add_row("Sync", _sync_source_label(args))
     return Panel(table, title="Hand-X Terminal", border_style="cyan")
@@ -438,9 +484,43 @@ async def _handle_review_prompt(
     console: Console,
 ) -> None:
     console.print(_review_panel(state))
-    complete = Confirm.ask("Mark review complete and close the browser?", default=False)
+    complete = Confirm.ask("Mark review complete and detach the engine?", default=False)
     command = {"type": "complete_review"} if complete else {"type": "cancel_job"}
     await _send_command(proc, command)
+
+
+async def _handle_hitl_prompt(
+    proc: asyncio.subprocess.Process,
+    state: TuiRunState,
+    console: Console,
+) -> None:
+    question = state.pending_question or {}
+    field_id = str(question.get("fieldId") or question.get("id") or "")
+    field_label = str(question.get("fieldLabel") or question.get("label") or field_id)
+    options = question.get("options")
+    console.print(f"\n[bold]{field_label}[/bold]")
+    if isinstance(options, list) and options:
+        skip_choice = "<skip>"
+        choices = [str(option) for option in options]
+        selected = Prompt.ask("Answer", choices=[*choices, skip_choice], default=choices[0])
+        answer = "" if selected == skip_choice else selected.strip()
+    else:
+        answer = Prompt.ask("Answer (leave blank to skip)", default="").strip()
+    if answer:
+        await _send_command(
+            proc,
+            {
+                "type": "answer_field",
+                "field_id": field_id,
+                "field_label": field_label,
+                "answer": answer,
+            },
+        )
+    else:
+        await _send_command(
+            proc,
+            {"type": "skip_field", "field_id": field_id, "field_label": field_label},
+        )
 
 
 async def _send_command(proc: asyncio.subprocess.Process, command: dict[str, Any]) -> None:

--- a/ghosthands/tui.py
+++ b/ghosthands/tui.py
@@ -497,9 +497,16 @@ async def _handle_hitl_prompt(
     question = state.pending_question or {}
     field_id = str(question.get("fieldId") or question.get("id") or "")
     field_label = str(question.get("fieldLabel") or question.get("label") or field_id)
+    field_type = str(question.get("fieldType") or question.get("type") or "text").lower()
     options = question.get("options")
     console.print(f"\n[bold]{field_label}[/bold]")
-    if isinstance(options, list) and options:
+    if field_type in {"checkbox", "checkboxes", "checkbox-group", "multi_select", "multi-select"}:
+        choices = [str(option) for option in options] if isinstance(options, list) else []
+        if choices:
+            answer: str | list[str] = [choice for choice in choices if Confirm.ask(choice, default=False)]
+        else:
+            answer = "true" if Confirm.ask("Answer", default=False) else ""
+    elif isinstance(options, list) and options:
         skip_choice = "<skip>"
         choices = [str(option) for option in options]
         selected = Prompt.ask("Answer", choices=[*choices, skip_choice], default=choices[0])
@@ -507,10 +514,11 @@ async def _handle_hitl_prompt(
     else:
         answer = Prompt.ask("Answer (leave blank to skip)", default="").strip()
     if answer:
+        save_answer = Confirm.ask("Save as verified answer?", default=False)
         await _send_command(
             proc,
             {
-                "type": "answer_field",
+                "type": "save_answer" if save_answer else "answer_field",
                 "field_id": field_id,
                 "field_label": field_label,
                 "answer": answer,

--- a/tests/ci/browser/test_tabs.py
+++ b/tests/ci/browser/test_tabs.py
@@ -140,6 +140,38 @@ async def test_same_tab_guard_forces_target_blank_navigation_into_current_tab(br
 	assert len(await browser_session.get_tabs()) == baseline_tabs
 
 
+@pytest.mark.asyncio
+async def test_review_guard_blocks_unknown_finalizer_through_browser_session(browser_session, base_url):
+	"""Exercise guard install and block-state reads through Browser Use's actor Page."""
+	from types import SimpleNamespace
+
+	from ghosthands.agent.hooks import consume_blocked_final_submit, install_final_submit_guard
+
+	await browser_session.navigate_to(f'{base_url}/background-tab-test')
+	page = await browser_session.get_current_page()
+	assert page is not None
+	await page.evaluate(
+		"""() => {
+			window.applicationSubmits = 0;
+			const finalizer = document.createElement('div');
+			finalizer.id = 'finalize';
+			finalizer.setAttribute('role', 'button');
+			finalizer.textContent = 'Finalize';
+			finalizer.addEventListener('click', () => { window.applicationSubmits += 1; });
+			document.body.appendChild(finalizer);
+		}"""
+	)
+	agent = SimpleNamespace(browser_session=browser_session)
+	await install_final_submit_guard(agent, allow_submit=False)
+
+	await page.evaluate("() => document.getElementById('finalize').click()")
+	blocked = await consume_blocked_final_submit(agent)
+
+	assert blocked is not None
+	assert blocked['blocked'] is True
+	assert await page.evaluate('() => window.applicationSubmits') == '0'
+
+
 class TestMultiTabOperations:
 	"""Test multi-tab creation, switching, and closing."""
 

--- a/tests/ci/test_cli_args.py
+++ b/tests/ci/test_cli_args.py
@@ -23,6 +23,17 @@ import pytest
 # Module-level setup: mock heavy imports before loading ghosthands.cli
 # ---------------------------------------------------------------------------
 
+_CLI_IMPORT_STUBS: set[str] = set()
+
+
+def _install_import_stub(name: str, module: types.ModuleType) -> types.ModuleType:
+    existing = sys.modules.get(name)
+    if existing is not None:
+        return existing
+    sys.modules[name] = module
+    _CLI_IMPORT_STUBS.add(name)
+    return module
+
 
 def _ensure_cli_importable():
     """Install lightweight mocks for browser-use dependency chain.
@@ -44,22 +55,22 @@ def _ensure_cli_importable():
         "browser_use.tools.service": types.ModuleType("browser_use.tools.service"),
     }
     for name, mod in stubs.items():
-        sys.modules.setdefault(name, mod)
+        _install_import_stub(name, mod)
 
     # Mock ghosthands.agent and its submodules to prevent cascading imports
     if "ghosthands.agent" not in sys.modules:
         mock_agent = types.ModuleType("ghosthands.agent")
-        sys.modules["ghosthands.agent"] = mock_agent
+        _install_import_stub("ghosthands.agent", mock_agent)
     else:
         mock_agent = sys.modules["ghosthands.agent"]
     if "ghosthands.agent.factory" not in sys.modules:
         mock_factory = types.ModuleType("ghosthands.agent.factory")
-        sys.modules["ghosthands.agent.factory"] = mock_factory
+        _install_import_stub("ghosthands.agent.factory", mock_factory)
     else:
         mock_factory = sys.modules["ghosthands.agent.factory"]
     if "ghosthands.agent.prompts" not in sys.modules:
         mock_prompts = types.ModuleType("ghosthands.agent.prompts")
-        sys.modules["ghosthands.agent.prompts"] = mock_prompts
+        _install_import_stub("ghosthands.agent.prompts", mock_prompts)
     else:
         mock_prompts = sys.modules["ghosthands.agent.prompts"]
     if "ghosthands.agent.hooks" not in sys.modules:
@@ -68,7 +79,7 @@ def _ensure_cli_importable():
         hooks_any.install_same_tab_guard = AsyncMock()
         hooks_any.install_final_submit_guard = AsyncMock()
         hooks_any.consume_blocked_final_submit = AsyncMock(return_value=None)
-        sys.modules["ghosthands.agent.hooks"] = mock_hooks
+        _install_import_stub("ghosthands.agent.hooks", mock_hooks)
     else:
         mock_hooks = sys.modules["ghosthands.agent.hooks"]
 
@@ -81,6 +92,19 @@ def _ensure_cli_importable():
 _ensure_cli_importable()
 
 from ghosthands.cli import parse_args  # noqa: E402
+
+
+def _restore_cli_import_stubs() -> None:
+    removed = {name: sys.modules.pop(name, None) for name in sorted(_CLI_IMPORT_STUBS, reverse=True)}
+    for parent_name, child_name in (("ghosthands", "agent"), ("browser_use", "agent"), ("browser_use", "browser")):
+        parent = sys.modules.get(parent_name)
+        child = getattr(parent, child_name, None) if parent is not None else None
+        if child is not None and getattr(child, "__name__", "") in removed:
+            delattr(parent, child_name)
+    _CLI_IMPORT_STUBS.clear()
+
+
+_restore_cli_import_stubs()
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -369,17 +393,32 @@ class TestDesktopBridgeArgs:
         args = _parse(["--job-url", "https://example.com"])
         assert args.cdp_url is None
 
-    def test_cdp_url_set(self):
-        """--cdp-url stores the provided CDP URL."""
+    def test_cdp_url_and_target_set(self):
+        """Desktop CDP connection requires and stores the exact target ID."""
         args = _parse(
             [
                 "--job-url",
                 "https://example.com",
                 "--cdp-url",
                 "ws://127.0.0.1:9222/devtools/browser/abc",
+                "--cdp-target-id",
+                "target-123",
             ]
         )
         assert args.cdp_url == "ws://127.0.0.1:9222/devtools/browser/abc"
+        assert args.cdp_target_id == "target-123"
+
+    def test_cdp_url_without_target_rejected(self):
+        """A browser endpoint alone must not select an arbitrary tab."""
+        with pytest.raises(SystemExit):
+            _parse(
+                [
+                    "--job-url",
+                    "https://example.com",
+                    "--cdp-url",
+                    "ws://127.0.0.1:9222/devtools/browser/abc",
+                ]
+            )
 
     def test_engine_default_auto(self):
         """--engine defaults to auto."""

--- a/tests/ci/test_run_agent_jsonl_flow.py
+++ b/tests/ci/test_run_agent_jsonl_flow.py
@@ -26,6 +26,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# Load these package modules before installing collection-time stubs so their
+# real parent-package bindings are restored for neighboring test modules.
+import ghosthands.agent.hooks
+import ghosthands.output
+
 # ---------------------------------------------------------------------------
 # Module-level setup: stub ALL the modules run_agent_jsonl imports from.
 # We track which modules we installed so we can restore them later.
@@ -43,6 +48,8 @@ _m_emit_account_created = MagicMock()
 _m_emit_error = MagicMock()
 _m_emit_done = MagicMock()
 _m_emit_awaiting_review = MagicMock()
+_m_emit_review_ready = MagicMock()
+_m_emit_run_state = MagicMock()
 _m_cleanup_browser = AsyncMock()
 
 
@@ -99,6 +106,8 @@ def _reset_mocks() -> None:
         _m_emit_error,
         _m_emit_done,
         _m_emit_awaiting_review,
+        _m_emit_review_ready,
+        _m_emit_run_state,
         _m_cleanup_browser,
     ]:
         m.reset_mock()
@@ -185,7 +194,13 @@ def _stub_all():
     go_jsonl.emit_error = _m_emit_error
     go_jsonl.emit_done = _m_emit_done
     go_jsonl.emit_awaiting_review = _m_emit_awaiting_review
+    go_jsonl.emit_review_ready = _m_emit_review_ready
+    go_jsonl.emit_run_state = _m_emit_run_state
     _install_stub("ghosthands.output.jsonl", go_jsonl)
+
+    go_history = types.ModuleType("ghosthands.output.agent_history_payload")
+    go_history.build_agent_history_payload = MagicMock(return_value=[])
+    _install_stub("ghosthands.output.agent_history_payload", go_history)
 
     go_jt = types.ModuleType("ghosthands.output.jsonl_terminal")
     go_jt.reset = MagicMock()
@@ -261,6 +276,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         "allowed_domains": None,
         "browsers_path": None,
         "cdp_url": None,
+        "cdp_target_id": None,
         "engine": "chromium",
     }
     defaults.update(overrides)
@@ -403,7 +419,7 @@ class TestRunAgentJsonlFlow:
         mock_agent = AsyncMock()
         mock_agent.state = MagicMock(n_steps=3, last_model_output=None, stopped=False)
 
-        async def _fake_listen_for_cancel(agent, cancel_requested):
+        async def _fake_listen_for_cancel(agent, cancel_requested, *, job_id=""):
             cancel_requested.set()
 
         async def _run_that_yields(**kwargs):

--- a/tests/ci/test_run_agent_jsonl_flow.py
+++ b/tests/ci/test_run_agent_jsonl_flow.py
@@ -530,11 +530,20 @@ class TestRunAgentJsonlFlow:
         _, kwargs = _m_emit_cost.call_args
         assert kwargs.get("total_usd") == 0.12
 
-    async def test_submit_guard_breach_marks_failure_in_review_mode(self):
+    @pytest.mark.parametrize(
+        "claim",
+        [
+            "Application submitted successfully",
+            "Successfully applied",
+            "Submitted",
+            "The application has been submitted",
+        ],
+    )
+    async def test_submit_guard_breach_marks_failure_in_review_mode(self, claim):
         """A run that reports submission while submit_intent=review must fail."""
         mock_history = _make_mock_history(
             is_done=True,
-            final_result="Application submitted successfully",
+            final_result=claim,
         )
         mock_browser = _make_mock_browser()
 
@@ -551,3 +560,24 @@ class TestRunAgentJsonlFlow:
         kwargs = _m_emit_done.call_args.kwargs
         assert kwargs["success"] is False
         assert "guard breach" in (kwargs.get("message") or "").lower()
+
+    async def test_submit_guard_breach_in_agent_history_is_removed_from_output(self):
+        mock_history = _make_mock_history(is_done=True, final_result="Application ready for review")
+        mock_browser = _make_mock_browser()
+        mock_agent = AsyncMock()
+        mock_agent.run = AsyncMock(return_value=mock_history)
+        mock_agent.state = MagicMock(n_steps=9, last_model_output=None, stopped=False)
+
+        with _apply_stubs_and_patches(mock_browser, mock_agent):
+            history_payload = sys.modules["ghosthands.output.agent_history_payload"].build_agent_history_payload
+            history_payload.return_value = [{"result": "Successfully applied"}]
+            with pytest.raises(SystemExit) as exc_info:
+                await run_agent_jsonl(_make_args())
+
+        assert exc_info.value.code == 1
+        _m_emit_awaiting_review.assert_not_called()
+        result_data = _m_emit_done.call_args.kwargs["result_data"]
+        assert "guard breach" in _m_emit_done.call_args.kwargs["message"].lower()
+        encoded = str(result_data).lower()
+        assert "successfully applied" not in encoded
+        assert "application submitted" not in encoded

--- a/tests/integration/test_bridge_protocol_real.py
+++ b/tests/integration/test_bridge_protocol_real.py
@@ -51,12 +51,16 @@ class _FakeBrowser:
 
     def __init__(self) -> None:
         self.closed = False
+        self.detached = False
 
     async def close(self) -> None:
         self.closed = True
 
     async def stop(self) -> None:
         self.closed = True
+
+    async def detach_keep_alive(self) -> None:
+        self.detached = True
 
 
 # ---------------------------------------------------------------------------
@@ -318,8 +322,8 @@ class TestListenForCancelReal:
 class TestWaitForReviewCommandReal:
     """Test ``wait_for_review_command`` with real pipes."""
 
-    async def test_complete_review_closes_browser(self):
-        """Sending ``complete_review`` should close the browser and return ``"complete"``."""
+    async def test_complete_review_detaches_without_closing_browser(self):
+        """Completing review detaches the engine while preserving the browser."""
         browser = _FakeBrowser()
         read_file, w = _make_pipe_stdin()
         old_stdin = sys.stdin
@@ -339,13 +343,14 @@ class TestWaitForReviewCommandReal:
                 ),
                 timeout=10.0,
             )
-            assert browser.closed is True
+            assert browser.detached is True
+            assert browser.closed is False
             assert results[0] == "complete"
         finally:
             sys.stdin = old_stdin
 
-    async def test_cancel_closes_browser(self):
-        """Sending ``cancel`` during review should close the browser and return ``"cancel"``."""
+    async def test_cancel_detaches_without_closing_browser(self):
+        """Cancelling review detaches the engine while preserving the browser."""
         browser = _FakeBrowser()
         read_file, w = _make_pipe_stdin()
         old_stdin = sys.stdin
@@ -365,13 +370,14 @@ class TestWaitForReviewCommandReal:
                 ),
                 timeout=10.0,
             )
-            assert browser.closed is True
+            assert browser.detached is True
+            assert browser.closed is False
             assert results[0] == "cancel"
         finally:
             sys.stdin = old_stdin
 
-    async def test_cancel_job_closes_browser(self):
-        """Sending ``cancel_job`` during review should close the browser and return ``"cancel"``."""
+    async def test_cancel_job_detaches_without_closing_browser(self):
+        """Cancelling the job detaches the engine while preserving the browser."""
         browser = _FakeBrowser()
         read_file, w = _make_pipe_stdin()
         old_stdin = sys.stdin
@@ -391,7 +397,8 @@ class TestWaitForReviewCommandReal:
                 ),
                 timeout=10.0,
             )
-            assert browser.closed is True
+            assert browser.detached is True
+            assert browser.closed is False
             assert results[0] == "cancel"
         finally:
             sys.stdin = old_stdin
@@ -420,13 +427,14 @@ class TestWaitForReviewCommandReal:
                 ),
                 timeout=10.0,
             )
-            assert browser.closed is True
+            assert browser.detached is True
+            assert browser.closed is False
             assert results[0] == "complete"
         finally:
             sys.stdin = old_stdin
 
-    async def test_eof_closes_browser(self):
-        """If stdin is closed (Electron died), the browser should be closed and return ``"eof"``."""
+    async def test_eof_detaches_without_closing_browser(self):
+        """If the parent dies, detach the engine and preserve the browser."""
         browser = _FakeBrowser()
         read_file, w = _make_pipe_stdin()
         old_stdin = sys.stdin
@@ -445,7 +453,8 @@ class TestWaitForReviewCommandReal:
                 ),
                 timeout=10.0,
             )
-            assert browser.closed is True
+            assert browser.detached is True
+            assert browser.closed is False
             assert results[0] == "eof"
         finally:
             sys.stdin = old_stdin

--- a/tests/integration/test_review_submit_guard.py
+++ b/tests/integration/test_review_submit_guard.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from playwright.async_api import async_playwright
+
+from ghosthands.agent.hooks import _FINAL_SUBMIT_GUARD_JS, _READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS
+from ghosthands.dom.fill_browser_scripts import _CLICK_CHECKBOX_GROUP_JS
+
+
+@pytest.mark.asyncio
+async def test_review_guard_blocks_all_submit_mechanisms_but_allows_next_navigation() -> None:
+    async with async_playwright() as playwright:
+        launch_options: dict[str, object] = {"headless": True}
+        if not Path(playwright.chromium.executable_path).exists():
+            cache_roots = [Path.home() / "Library/Caches/ms-playwright", Path.home() / ".cache/ms-playwright"]
+            cached = [path for root in cache_roots if root.exists() for path in root.rglob("chrome-headless-shell")]
+            if cached:
+                launch_options["executable_path"] = str(sorted(cached)[-1])
+        browser = await playwright.chromium.launch(**launch_options)
+        page = await browser.new_page()
+        await page.set_content(
+            """
+            <form id="candidate" onsubmit="window.applicationSubmits += 1; return false">
+              <input name="name" value="Ada">
+              <button id="apply" type="submit">Apply</button>
+            </form>
+            <form id="navigation" onsubmit="window.navigationSubmits += 1; return false">
+              <button id="next" type="submit">Next</button>
+            </form>
+            <script>window.applicationSubmits = 0; window.navigationSubmits = 0;</script>
+            """
+        )
+        await page.evaluate(_FINAL_SUBMIT_GUARD_JS)
+
+        await page.click("#apply")
+        click_block = await page.evaluate(_READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS)
+        await page.evaluate("document.querySelector('#candidate').requestSubmit()")
+        request_block = await page.evaluate(_READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS)
+        await page.evaluate("document.querySelector('#candidate').submit()")
+        submit_block = await page.evaluate(_READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS)
+        await page.click("#next")
+        next_block = await page.evaluate(_READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS)
+
+        assert click_block["blocked"] is True
+        assert request_block["blocked"] is True
+        assert submit_block["blocked"] is True
+        assert await page.evaluate("window.applicationSubmits") == 0
+        assert next_block is None
+        assert await page.evaluate("window.navigationSubmits") == 1
+        await browser.close()
+
+
+@pytest.mark.asyncio
+async def test_checkbox_group_script_selects_every_requested_answer() -> None:
+    async with async_playwright() as playwright:
+        launch_options: dict[str, object] = {"headless": True}
+        if not Path(playwright.chromium.executable_path).exists():
+            cache_roots = [Path.home() / "Library/Caches/ms-playwright", Path.home() / ".cache/ms-playwright"]
+            cached = [path for root in cache_roots if root.exists() for path in root.rglob("chrome-headless-shell")]
+            if cached:
+                launch_options["executable_path"] = str(sorted(cached)[-1])
+        browser = await playwright.chromium.launch(**launch_options)
+        page = await browser.new_page()
+        await page.set_content(
+            """
+            <fieldset id="skills" class="checkbox-group">
+              <label><input type="checkbox" value="Python">Python</label>
+              <label><input type="checkbox" value="Go">Go</label>
+              <label><input type="checkbox" value="Rust">Rust</label>
+            </fieldset>
+            <script>
+              window.__ff = {
+                byId: (id) => document.getElementById(id),
+                closestCrossRoot: (node, selector) => node.closest(selector),
+                queryOne: (selector) => document.querySelector(selector),
+              };
+            </script>
+            """
+        )
+
+        result = await page.evaluate(f"({_CLICK_CHECKBOX_GROUP_JS})('skills', 'Python, Go')")
+
+        assert result == '{"clicked":true,"alreadyChecked":false,"matchedCount":2}'
+        assert await page.locator('input[value="Python"]').is_checked()
+        assert await page.locator('input[value="Go"]').is_checked()
+        assert not await page.locator('input[value="Rust"]').is_checked()
+        await browser.close()

--- a/tests/integration/test_review_submit_guard.py
+++ b/tests/integration/test_review_submit_guard.py
@@ -53,6 +53,34 @@ async def test_review_guard_blocks_all_submit_mechanisms_but_allows_next_navigat
 
 
 @pytest.mark.asyncio
+async def test_review_guard_blocks_unknown_javascript_finalizer() -> None:
+    async with async_playwright() as playwright:
+        launch_options: dict[str, object] = {"headless": True}
+        if not Path(playwright.chromium.executable_path).exists():
+            cache_roots = [Path.home() / "Library/Caches/ms-playwright", Path.home() / ".cache/ms-playwright"]
+            cached = [path for root in cache_roots if root.exists() for path in root.rglob("chrome-headless-shell")]
+            if cached:
+                launch_options["executable_path"] = str(sorted(cached)[-1])
+        browser = await playwright.chromium.launch(**launch_options)
+        page = await browser.new_page()
+        await page.set_content(
+            """
+            <div id="finalize" role="button" tabindex="0"
+                 onclick="window.applicationSubmits += 1">Finalize</div>
+            <script>window.applicationSubmits = 0;</script>
+            """
+        )
+        await page.evaluate(_FINAL_SUBMIT_GUARD_JS)
+
+        await page.click("#finalize")
+        blocked = await page.evaluate(_READ_AND_CLEAR_FINAL_SUBMIT_BLOCK_JS)
+
+        assert blocked["blocked"] is True
+        assert await page.evaluate("window.applicationSubmits") == 0
+        await browser.close()
+
+
+@pytest.mark.asyncio
 async def test_checkbox_group_script_selects_every_requested_answer() -> None:
     async with async_playwright() as playwright:
         launch_options: dict[str, object] = {"headless": True}

--- a/tests/unit/test_desktop_bridge.py
+++ b/tests/unit/test_desktop_bridge.py
@@ -146,7 +146,7 @@ class TestEmitAwaitingReview:
         events = _capture_jsonl_output(emit_awaiting_review)
         assert events[0]["message"] == (
             "We've filled out your application. Please review the form in the browser "
-            "window, verify all fields are correct, then click Submit in the app."
+            "window, verify all fields are correct, then mark review complete."
         )
 
     def test_custom_message_is_emitted(self):
@@ -2026,7 +2026,7 @@ class TestWaitForReviewCommand:
     complete_review, cancel, and timeout scenarios."""
 
     @pytest.mark.asyncio
-    async def test_complete_review_closes_browser(self):
+    async def test_complete_review_detaches_without_closing_browser(self):
         from ghosthands.bridge.protocol import wait_for_review_command
 
         browser = AsyncMock()
@@ -2039,10 +2039,11 @@ class TestWaitForReviewCommand:
             result = await wait_for_review_command(browser, "j1", "l1")
 
         assert result == "complete"
-        browser.stop.assert_called_once()
+        browser.detach_keep_alive.assert_awaited_once()
+        browser.stop.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_cancel_during_review_closes_browser(self):
+    async def test_cancel_during_review_detaches_without_closing_browser(self):
         from ghosthands.bridge.protocol import wait_for_review_command
 
         browser = AsyncMock()
@@ -2055,11 +2056,12 @@ class TestWaitForReviewCommand:
             result = await wait_for_review_command(browser, "j1", "l1")
 
         assert result == "cancel"
-        browser.stop.assert_called_once()
+        browser.detach_keep_alive.assert_awaited_once()
+        browser.stop.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_eof_during_review_closes_browser(self):
-        """EOF (Electron crashed) should cleanly close browser."""
+    async def test_eof_during_review_preserves_browser(self):
+        """EOF (Desktop crashed) detaches while preserving the selected tab."""
         from ghosthands.bridge.protocol import wait_for_review_command
 
         browser = AsyncMock()
@@ -2071,7 +2073,8 @@ class TestWaitForReviewCommand:
             result = await wait_for_review_command(browser, "j1", "l1")
 
         assert result == "eof"
-        browser.stop.assert_called_once()
+        browser.detach_keep_alive.assert_awaited_once()
+        browser.stop.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_ignores_unknown_commands_during_review(self):
@@ -2092,7 +2095,8 @@ class TestWaitForReviewCommand:
             result = await wait_for_review_command(browser, "j1", "l1")
 
         assert result == "complete"
-        browser.stop.assert_called_once()
+        browser.detach_keep_alive.assert_awaited_once()
+        browser.stop.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_timeout_emits_warning_before_fatal_error(self):
@@ -2116,18 +2120,19 @@ class TestWaitForReviewCommand:
 
         assert result == "timeout"
         emit_status.assert_any_call(
-            "Your review session will expire in about 1 hour. Please submit or cancel soon.",
+            "Your review session will expire in about 1 hour. Please mark review complete or cancel soon.",
             job_id="j1",
         )
         emit_error.assert_called_once_with(
-            "Review session expired — please submit or cancel your application",
+            "Review session expired; the engine detached and the browser tab remains open",
             fatal=True,
             job_id="j1",
         )
-        browser.stop.assert_called_once()
+        browser.detach_keep_alive.assert_awaited_once()
+        browser.stop.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_no_warning_if_submitted_before_timeout(self):
+    async def test_no_warning_if_review_completed_before_timeout(self):
         from ghosthands.bridge.protocol import wait_for_review_command
 
         browser = AsyncMock()
@@ -2147,11 +2152,12 @@ class TestWaitForReviewCommand:
             result = await wait_for_review_command(browser, "j1", "l1")
 
         assert result == "complete"
-        emit_status.assert_any_call("Review complete -- closing browser", job_id="j1")
-        assert ("Your review session will expire in 5 minutes. Please submit or cancel soon.",) not in [
+        emit_status.assert_any_call("Review complete -- detaching engine", job_id="j1")
+        assert ("Your review session will expire in about 1 hour. Please mark review complete or cancel soon.",) not in [
             call.args for call in emit_status.call_args_list
         ]
-        browser.stop.assert_called_once()
+        browser.detach_keep_alive.assert_awaited_once()
+        browser.stop.assert_not_called()
 
 
 class TestReviewOutcomeHandling:
@@ -2179,7 +2185,7 @@ class TestReviewOutcomeHandling:
         emit_terminal.assert_called_once_with(
             termination_status="review_timeout",
             success=False,
-            message="Review timed out after 30 minutes. The browser window is still open — you can submit manually.",
+            message="Review timed out; the browser tab remains open and the engine detached.",
             fields_filled=8,
             fields_failed=2,
             job_id="job-1",

--- a/tests/unit/test_repeater_commit_js.py
+++ b/tests/unit/test_repeater_commit_js.py
@@ -1,15 +1,16 @@
-"""Playwright-based tests for _CLICK_SAVE_BUTTON_JS.
+"""Playwright-based tests for the repeater commit-button finder and click flow.
 
 Spins up a real browser page with mock Oracle-like buttons and runs the
 actual JavaScript to verify it clicks the RIGHT button for each section.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 from playwright.sync_api import sync_playwright
 
-from ghosthands.actions.domhand_fill_repeaters import _CLICK_SAVE_BUTTON_JS
+from ghosthands.actions.domhand_fill_repeaters import _FIND_SAVE_BUTTON_JS
 
 # ── Fixtures ──────────────────────────────────────────────────────────
 
@@ -17,7 +18,13 @@ from ghosthands.actions.domhand_fill_repeaters import _CLICK_SAVE_BUTTON_JS
 @pytest.fixture(scope="module")
 def browser():
     with sync_playwright() as p:
-        b = p.chromium.launch(headless=True)
+        launch_options: dict[str, object] = {"headless": True}
+        if not Path(p.chromium.executable_path).exists():
+            cache_roots = [Path.home() / "Library/Caches/ms-playwright", Path.home() / ".cache/ms-playwright"]
+            cached = [path for root in cache_roots if root.exists() for path in root.rglob("chrome-headless-shell")]
+            if cached:
+                launch_options["executable_path"] = str(sorted(cached)[-1])
+        b = p.chromium.launch(**launch_options)
         yield b
         b.close()
 
@@ -56,9 +63,14 @@ def _make_oracle_page(page, buttons: list[str], *, hidden_buttons: list[str] | N
 
 
 def _run_save_js(page, section_hint: str) -> dict:
-    """Run _CLICK_SAVE_BUTTON_JS and return the parsed result."""
-    raw = page.evaluate(_CLICK_SAVE_BUTTON_JS, section_hint)
-    return json.loads(raw) if isinstance(raw, str) else raw
+    """Run the production find-then-locator-click flow."""
+    raw = page.evaluate(_FIND_SAVE_BUTTON_JS, section_hint)
+    result = json.loads(raw) if isinstance(raw, str) else raw
+    result["clicked"] = False
+    if result.get("found"):
+        page.locator('[data-dh-commit-target="true"]').click()
+        result["clicked"] = True
+    return result
 
 
 def _get_clicked_text(page) -> str:
@@ -79,7 +91,7 @@ class TestSkillsCommit:
         assert "skill" in result["text"].lower()
         assert _get_clicked_text(page) == "Add Skill"
 
-    def test_clicks_ADD_SKILL_uppercase(self, page):
+    def test_clicks_add_skill_uppercase(self, page):
         _make_oracle_page(page, ["CANCEL", "ADD SKILL", "ADD EDUCATION", "ADD LANGUAGE"])
         result = _run_save_js(page, "skills")
         assert result["clicked"] is True
@@ -211,18 +223,18 @@ class TestCrossSectionIsolation:
     def test_skills_ignores_add_education_and_add_language(self, page):
         """When filling skills, only 'Add Skill' should be clickable, not others."""
         _make_oracle_page(page, ["Add Education", "Add Language", "SAVE", "Add Skill"])
-        result = _run_save_js(page, "skills")
+        _run_save_js(page, "skills")
         assert _get_clicked_text(page) == "Add Skill"
 
     def test_languages_ignores_add_skill_and_add_education(self, page):
         _make_oracle_page(page, ["Add Skill", "Add Education", "SAVE", "Add Language"])
-        result = _run_save_js(page, "languages")
+        _run_save_js(page, "languages")
         assert _get_clicked_text(page) == "Add Language"
 
     def test_education_ignores_add_skill_and_add_language(self, page):
         """Education should click SAVE, never Add Skill or Add Language."""
         _make_oracle_page(page, ["Add Skill", "Add Language", "SAVE", "Add Education"])
-        result = _run_save_js(page, "education")
+        _run_save_js(page, "education")
         assert _get_clicked_text(page) == "SAVE"
 
     def test_all_add_buttons_present_skills_picks_right_one(self, page):

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import io
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from rich.console import Console
 
 from ghosthands.tui import TuiRunState, _render_state, build_engine_argv, parse_jsonl_event
@@ -92,6 +94,39 @@ def test_tui_state_redacts_password_values():
     state.apply_event(event)
 
     assert state.logs[-1] == ("filled", "password: [redacted]")
+
+
+@pytest.mark.asyncio
+async def test_tui_checkbox_prompt_sends_saved_multi_answer(monkeypatch):
+    from argparse import Namespace
+
+    from ghosthands.tui import TuiRunState, _handle_hitl_prompt
+
+    state = TuiRunState(
+        pending_question={
+            "fieldId": "skills",
+            "fieldLabel": "Skills",
+            "fieldType": "checkbox",
+            "options": ["Python", "Go"],
+        }
+    )
+    proc = Namespace(stdin=AsyncMock())
+    sent: list[dict] = []
+    monkeypatch.setattr("ghosthands.tui.Confirm.ask", MagicMock(side_effect=[True, True, True]))
+    monkeypatch.setattr(
+        "ghosthands.tui._send_command", AsyncMock(side_effect=lambda _proc, command: sent.append(command))
+    )
+
+    await _handle_hitl_prompt(proc, state, MagicMock())
+
+    assert sent == [
+        {
+            "type": "save_answer",
+            "field_id": "skills",
+            "field_label": "Skills",
+            "answer": ["Python", "Go"],
+        }
+    ]
 
 
 def test_tui_render_treats_log_messages_as_plain_text():

--- a/tests/unit/test_valet_runtime_contract.py
+++ b/tests/unit/test_valet_runtime_contract.py
@@ -1,0 +1,317 @@
+"""Focused tests for the Hand-X boundary consumed by the Go VALET runtime."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import io
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _parse(monkeypatch: pytest.MonkeyPatch, *args: str) -> argparse.Namespace:
+    from ghosthands.cli import parse_args
+
+    monkeypatch.setattr(sys, "argv", ["hand-x", *args])
+    return parse_args()
+
+
+def _capture_events(callback) -> list[dict]:
+    output = io.StringIO()
+    with patch("ghosthands.output.jsonl._get_output", return_value=output):
+        callback()
+    return [json.loads(line) for line in output.getvalue().splitlines()]
+
+
+def test_cli_accepts_go_cdp_target_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    args = _parse(
+        monkeypatch,
+        "--job-url",
+        "https://example.com/job",
+        "--cdp-url",
+        "http://127.0.0.1:49321",
+        "--cdp-target-id",
+        "target-a",
+    )
+
+    assert args.cdp_target_id == "target-a"
+
+
+@pytest.mark.asyncio
+async def test_missing_requested_chrome_target_fails_without_creating_a_tab() -> None:
+    from browser_use.browser.session import BrowserSession
+
+    session = BrowserSession(
+        cdp_url="ws://127.0.0.1:9222/devtools/browser/shared",
+        target_id="target-missing",
+    )
+    cdp_client = AsyncMock()
+    cdp_client.send = MagicMock()
+    cdp_client.send.Target = MagicMock()
+    cdp_client.send.Target.setAutoAttach = AsyncMock()
+    cdp_client.send.Target.createTarget = AsyncMock(return_value={"targetId": "replacement"})
+    manager = MagicMock()
+    manager.start_monitoring = AsyncMock()
+    manager.get_all_page_targets.return_value = []
+    manager.clear = AsyncMock()
+
+    with (
+        patch("browser_use.browser.session.CDPClient", return_value=cdp_client),
+        patch("browser_use.browser.session_manager.SessionManager", return_value=manager),
+        pytest.raises(RuntimeError, match="target-missing"),
+    ):
+        await session.connect()
+
+    cdp_client.send.Target.createTarget.assert_not_awaited()
+
+
+def test_public_tui_always_forces_review_intent() -> None:
+    from ghosthands.tui import build_engine_argv
+
+    args = argparse.Namespace(
+        job_url="https://example.com/job",
+        profile='{"first_name":"Jane"}',
+        test_data=None,
+        user_id=None,
+        resume_id=None,
+        resume=None,
+        job_id="job-1",
+        lease_id="lease-1",
+        model=None,
+        max_steps=20,
+        max_budget=0.5,
+        submit_intent="submit",
+        proxy_url=None,
+        runtime_grant=None,
+        allowed_domains=None,
+        browsers_path=None,
+        cdp_url=None,
+        cdp_target_id=None,
+        engine="auto",
+        headless=False,
+        output_format="tui",
+    )
+
+    argv = build_engine_argv(args, executable=["hand-x"])
+
+    index = argv.index("--submit-intent")
+    assert argv[index + 1] == "review"
+    assert "submit" not in argv
+
+
+def test_tui_accepts_canonical_go_review_event() -> None:
+    from ghosthands.tui import TuiRunState, parse_jsonl_event
+
+    event = parse_jsonl_event(
+        '{"type":"review_ready","status":"review_ready","version":8,'
+        '"message":"Review the completed form","targetId":"target-a"}'
+    )
+
+    assert event is not None
+    state = TuiRunState()
+    state.apply_event(event)
+    assert state.review_ready is True
+    assert state.phase == "Review"
+
+
+def test_go_jsonl_contract_is_versioned_and_never_reports_submission() -> None:
+    from ghosthands.output.jsonl import (
+        emit_cost,
+        emit_handshake,
+        emit_needs_answer,
+        emit_review_ready,
+    )
+
+    def emit() -> None:
+        emit_handshake()
+        emit_cost(0.12, cost_summary={"total_tracked_cost_usd": 0.12})
+        emit_needs_answer(
+            field_id="field-1",
+            label="Authorized to work?",
+            field_type="choice",
+            options=["Yes", "No"],
+            required=True,
+            section="Eligibility",
+        )
+        emit_review_ready(
+            cdp_url="http://127.0.0.1:49321",
+            target_id="target-a",
+            page_url="https://example.com/job",
+            cost_summary={"total_tracked_cost_usd": 0.12},
+        )
+
+    events = _capture_events(emit)
+
+    assert [event["version"] for event in events] == list(range(1, len(events) + 1))
+    assert all(event["type"] == event["event"] for event in events)
+    assert events[1]["type"] == "cost"
+    assert events[1]["costSummary"]["actualCostCents"] == 12
+    assert events[2]["status"] == "waiting_human"
+    assert events[2]["questions"] == [
+        {
+            "fieldId": "field-1",
+            "fieldLabel": "Authorized to work?",
+            "fieldType": "choice",
+            "options": ["Yes", "No"],
+            "required": True,
+            "section": "Eligibility",
+        }
+    ]
+    assert events[3]["status"] == "review_ready"
+    encoded = json.dumps(events).lower()
+    assert '"status":"submitted"' not in encoded
+    assert '"status":"applied"' not in encoded
+
+
+class _PauseableAgent:
+    def __init__(self) -> None:
+        self.state = SimpleNamespace(stopped=False, paused=False)
+        self.browser_session = SimpleNamespace(
+            cdp_url="http://127.0.0.1:49321",
+            agent_focus_target_id="target-a",
+        )
+        self._external_pause_event = asyncio.Event()
+        self._external_pause_event.set()
+        self.pause_calls = 0
+        self.resume_calls = 0
+        self.stop_calls = 0
+
+    def pause(self) -> None:
+        self.pause_calls += 1
+        self.state.paused = True
+        self._external_pause_event.clear()
+
+    def resume(self) -> None:
+        self.resume_calls += 1
+        self.state.paused = False
+        self._external_pause_event.set()
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+        self.state.stopped = True
+        self._external_pause_event.set()
+
+
+@pytest.mark.asyncio
+async def test_pause_resume_commands_gate_actions_without_browser_cleanup() -> None:
+    from ghosthands.bridge import protocol
+
+    protocol.reset_hitl_state()
+    agent = _PauseableAgent()
+    commands: asyncio.Queue[str] = asyncio.Queue()
+
+    async def read_command(timeout: float | None = None) -> str:
+        return await asyncio.wait_for(commands.get(), timeout=timeout)
+
+    async def next_action() -> None:
+        assert await protocol.wait_for_run_resume() is True
+
+    with (
+        patch("ghosthands.bridge.protocol.read_stdin_line", side_effect=read_command),
+        patch("ghosthands.output.jsonl.emit_paused") as emit_paused,
+        patch("ghosthands.output.jsonl.emit_resumed") as emit_resumed,
+    ):
+        listener = asyncio.create_task(protocol.listen_for_cancel(agent, job_id="job-1"))
+        await commands.put('{"type":"pause_job"}\n')
+        async with asyncio.timeout(1):
+            while not agent.state.paused:
+                await asyncio.sleep(0)
+
+        action = asyncio.create_task(next_action())
+        await asyncio.sleep(0)
+        assert action.done() is False
+
+        await commands.put('{"type":"resume_job"}\n')
+        await asyncio.wait_for(action, timeout=1)
+        await commands.put('{"type":"cancel_job"}\n')
+        await asyncio.wait_for(listener, timeout=1)
+
+    assert agent.pause_calls == 1
+    assert agent.resume_calls == 1
+    assert agent.stop_calls == 1
+    assert protocol.is_hitl_available() is False
+    assert await protocol.wait_for_run_resume() is False
+    protocol.reset_hitl_state()
+    assert await protocol.wait_for_run_resume() is True
+    emit_paused.assert_called_once()
+    emit_resumed.assert_called_once()
+
+    review_browser = SimpleNamespace(
+        agent_focus_target_id="target-a",
+        detach_keep_alive=AsyncMock(),
+    )
+    review_commands = [
+        '{"type":"pause_job"}\n',
+        '{"type":"resume_job"}\n',
+        '{"type":"complete_review"}\n',
+    ]
+    with (
+        patch("ghosthands.bridge.protocol.read_stdin_line", new=AsyncMock(side_effect=review_commands)),
+        patch("ghosthands.output.jsonl.emit_paused") as review_paused,
+        patch("ghosthands.output.jsonl.emit_resumed") as review_resumed,
+        patch("ghosthands.output.jsonl.emit_run_state"),
+        patch("ghosthands.output.jsonl.emit_status"),
+    ):
+        result = await protocol.wait_for_review_command(review_browser, "job-1", "lease-1")
+
+    assert result == "complete"
+    review_paused.assert_called_once()
+    review_resumed.assert_called_once()
+    review_browser.detach_keep_alive.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_review_guard_init_failure_is_fatal() -> None:
+    hooks = importlib.import_module("ghosthands.agent.hooks")
+
+    browser = MagicMock()
+    browser._cdp_add_init_script = AsyncMock(side_effect=RuntimeError("CDP rejected script"))
+    browser.get_current_page = AsyncMock()
+    hooks._FINAL_SUBMIT_GUARD_INSTALLED.discard(id(browser))
+
+    with pytest.raises(RuntimeError, match="CDP rejected script"):
+        await hooks.install_final_submit_guard(SimpleNamespace(browser_session=browser), allow_submit=False)
+
+    browser.get_current_page.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_review_guard_current_page_failure_is_fatal() -> None:
+    hooks = importlib.import_module("ghosthands.agent.hooks")
+
+    page = MagicMock()
+    page.evaluate = AsyncMock(side_effect=RuntimeError("page rejected script"))
+    browser = MagicMock()
+    browser._cdp_add_init_script = AsyncMock()
+    browser.get_current_page = AsyncMock(return_value=page)
+    hooks._FINAL_SUBMIT_GUARD_INSTALLED.discard(id(browser))
+
+    with pytest.raises(RuntimeError, match="page rejected script"):
+        await hooks.install_final_submit_guard(SimpleNamespace(browser_session=browser), allow_submit=False)
+
+
+def test_completed_review_result_never_claims_submitted_or_applied() -> None:
+    from ghosthands.cli import _handle_review_result
+
+    with patch("ghosthands.output.jsonl_terminal.emit_run_terminal") as emit_terminal:
+        result = _handle_review_result(
+            "complete",
+            fields_filled=3,
+            fields_failed=0,
+            job_id="job-1",
+            lease_id="lease-1",
+            result_data={"success": True},
+            cost_summary={},
+            total_cost_usd=0.0,
+        )
+
+    assert result is None
+    payload = emit_terminal.call_args.kwargs
+    encoded = json.dumps(payload).lower()
+    assert "submitted" not in encoded
+    assert "applied" not in encoded

--- a/tests/unit/test_valet_runtime_contract.py
+++ b/tests/unit/test_valet_runtime_contract.py
@@ -70,6 +70,68 @@ async def test_missing_requested_chrome_target_fails_without_creating_a_tab() ->
     cdp_client.send.Target.createTarget.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_selected_chrome_target_is_the_only_visible_or_switchable_page() -> None:
+    from browser_use.browser.events import CloseTabEvent, NavigateToUrlEvent, SwitchTabEvent
+    from browser_use.browser.session import BrowserSession
+
+    session = BrowserSession(
+        cdp_url="ws://127.0.0.1:9222/devtools/browser/shared",
+        target_id="target-a",
+    )
+    session.agent_focus_target_id = "target-a"
+    session.session_manager = MagicMock()
+    session.session_manager.get_all_page_targets.return_value = [
+        SimpleNamespace(target_id="target-a"),
+        SimpleNamespace(target_id="target-b"),
+    ]
+    cdp_client = AsyncMock()
+    cdp_client.send = MagicMock()
+    cdp_client.send.Target = MagicMock()
+    cdp_client.send.Target.createTarget = AsyncMock()
+    cdp_client.send.Target.closeTarget = AsyncMock()
+    session._cdp_client_root = cdp_client
+
+    assert [page._target_id for page in await session.get_pages()] == ["target-a"]
+    assert [target.target_id for target in session.get_page_targets()] == ["target-a"]
+    with pytest.raises(RuntimeError, match="locked to Chrome target target-a"):
+        await session.new_page("https://example.com")
+    with pytest.raises(RuntimeError, match="locked to Chrome target target-a"):
+        await session.on_SwitchTabEvent(SwitchTabEvent(target_id="target-b"))
+    with pytest.raises(RuntimeError, match="locked to Chrome target target-a"):
+        await session.close_page("target-a")
+    with pytest.raises(RuntimeError, match="locked to Chrome target target-a"):
+        await session.on_CloseTabEvent(CloseTabEvent(target_id="target-a"))
+    session.agent_focus_target_id = None
+    with pytest.raises(RuntimeError, match="lost locked Chrome target target-a"):
+        await session.on_NavigateToUrlEvent(NavigateToUrlEvent(url="https://example.com/next"))
+
+    cdp_client.send.Target.createTarget.assert_not_awaited()
+    cdp_client.send.Target.closeTarget.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_workday_preface_refuses_to_replace_missing_selected_target() -> None:
+    from ghosthands.cli import _run_workday_auth_preface
+
+    browser = SimpleNamespace(
+        _initial_target_id="target-a",
+        get_current_page=AsyncMock(return_value=None),
+        new_page=AsyncMock(),
+    )
+    settings = SimpleNamespace(email="user@example.com", password="secret")
+
+    with pytest.raises(RuntimeError, match="target-a"):
+        await _run_workday_auth_preface(
+            browser,
+            job_url="https://example.com/job",
+            app_settings=settings,
+            platform="workday",
+        )
+
+    browser.new_page.assert_not_awaited()
+
+
 def test_public_tui_always_forces_review_intent() -> None:
     from ghosthands.tui import build_engine_argv
 
@@ -168,6 +230,33 @@ def test_go_jsonl_contract_is_versioned_and_never_reports_submission() -> None:
     assert '"status":"applied"' not in encoded
 
 
+@pytest.mark.parametrize(
+    ("raw_type", "expected_type"),
+    [
+        ("textarea", "text"),
+        ("select", "choice"),
+        ("radio-group", "choice"),
+        ("checkbox-group", "checkbox"),
+        ("multi_select", "checkbox"),
+    ],
+)
+def test_needs_answer_normalizes_field_types_for_go(raw_type: str, expected_type: str) -> None:
+    from ghosthands.output.jsonl import emit_needs_answer
+
+    events = _capture_events(
+        lambda: emit_needs_answer(
+            field_id="field-1",
+            label="Question",
+            field_type=raw_type,
+            options=["One", "Two"],
+            required=True,
+            section="Screening",
+        )
+    )
+
+    assert events[0]["questions"][0]["fieldType"] == expected_type
+
+
 class _PauseableAgent:
     def __init__(self) -> None:
         self.state = SimpleNamespace(stopped=False, paused=False)
@@ -263,6 +352,74 @@ async def test_pause_resume_commands_gate_actions_without_browser_cleanup() -> N
     review_paused.assert_called_once()
     review_resumed.assert_called_once()
     review_browser.detach_keep_alive.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_save_answer_and_multi_checkbox_answers_are_consumed_from_stdin() -> None:
+    from ghosthands.bridge import protocol
+
+    protocol.reset_hitl_state()
+    agent = _PauseableAgent()
+    commands: asyncio.Queue[str] = asyncio.Queue()
+
+    async def read_command(timeout: float | None = None) -> str:
+        return await asyncio.wait_for(commands.get(), timeout=timeout)
+
+    with patch("ghosthands.bridge.protocol.read_stdin_line", side_effect=read_command):
+        listener = asyncio.create_task(protocol.listen_for_cancel(agent, job_id="job-1"))
+        await commands.put(
+            '{"type":"save_answer","field_id":"skills","field_label":"Skills","answer":["Python","Go"]}\n'
+        )
+        answer = await protocol.get_field_answer("skills", field_label="Skills", timeout=1)
+        await commands.put('{"type":"cancel_job"}\n')
+        await asyncio.wait_for(listener, timeout=1)
+
+    assert answer == "Python, Go"
+    assert protocol.consume_field_answer_save("skills", field_label="Skills") is True
+
+
+@pytest.mark.parametrize(
+    "claim",
+    [
+        "Successfully applied",
+        "Submitted",
+        "The application has been submitted",
+        "Applied successfully",
+    ],
+)
+def test_review_mode_rejects_every_submitted_or_applied_success_claim(claim: str) -> None:
+    from ghosthands.cli import _review_output_has_forbidden_success_claim
+
+    assert _review_output_has_forbidden_success_claim(claim) is True
+
+
+@pytest.mark.parametrize(
+    "safe_text",
+    [
+        "Application ready for review",
+        "The application was not submitted",
+        "Final submit was blocked",
+    ],
+)
+def test_review_mode_allows_non_submission_copy(safe_text: str) -> None:
+    from ghosthands.cli import _review_output_has_forbidden_success_claim
+
+    assert _review_output_has_forbidden_success_claim(safe_text) is False
+
+
+def test_multi_checkbox_answer_preserves_every_exact_choice() -> None:
+    from ghosthands.actions.views import FormField
+    from ghosthands.dom.fill_label_match import _coerce_answer_to_field
+
+    field = FormField(
+        field_id="skills",
+        name="Skills",
+        field_type="checkbox-group",
+        choices=["Python", "Go", "Rust"],
+    )
+
+    assert _coerce_answer_to_field(field, "python, GO") == "Python, Go"
+    assert _coerce_answer_to_field(field, "Python, Unknown") is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_valet_runtime_contract.py
+++ b/tests/unit/test_valet_runtime_contract.py
@@ -111,6 +111,39 @@ async def test_selected_chrome_target_is_the_only_visible_or_switchable_page() -
 
 
 @pytest.mark.asyncio
+async def test_selected_chrome_target_loss_never_recovers_to_another_tab() -> None:
+    from browser_use.browser.session_manager import SessionManager
+
+    cdp_client = AsyncMock()
+    cdp_client.send = MagicMock()
+    cdp_client.send.Target = MagicMock()
+    cdp_client.send.Target.activateTarget = AsyncMock()
+    browser = SimpleNamespace(
+        logger=MagicMock(),
+        _initial_target_id="target-a",
+        _detaching_keep_alive=False,
+        _cdp_client_root=cdp_client,
+        _cdp_create_new_page=AsyncMock(),
+        agent_focus_target_id=None,
+        event_bus=MagicMock(),
+    )
+    manager = SessionManager(browser)
+    manager._targets["target-b"] = SimpleNamespace(
+        target_id="target-b",
+        target_type="page",
+        url="https://mail.example.com",
+    )
+    manager._target_sessions["target-b"] = {"session-b"}
+    manager._sessions["session-b"] = SimpleNamespace(target_id="target-b")
+
+    await manager._recover_agent_focus("target-a")
+
+    assert browser.agent_focus_target_id is None
+    cdp_client.send.Target.activateTarget.assert_not_awaited()
+    browser._cdp_create_new_page.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_workday_preface_refuses_to_replace_missing_selected_target() -> None:
     from ghosthands.cli import _run_workday_auth_preface
 
@@ -407,6 +440,59 @@ def test_review_mode_allows_non_submission_copy(safe_text: str) -> None:
     assert _review_output_has_forbidden_success_claim(safe_text) is False
 
 
+def test_review_mode_detects_success_claims_in_normalized_keys() -> None:
+    from ghosthands.cli import _redact_review_success_claims, _review_output_has_forbidden_success_claim
+
+    payload = {
+        "submitted": True,
+        "nested": {"applicationSubmitted": True, "applied_successfully": True},
+    }
+
+    assert _review_output_has_forbidden_success_claim(payload) is True
+    redacted = _redact_review_success_claims(payload)
+    encoded = json.dumps(redacted).lower()
+    assert "submitted" not in encoded
+    assert "applied" not in encoded
+
+
+def test_review_mode_allows_internal_next_form_navigation() -> None:
+    from ghosthands.cli import _review_output_has_forbidden_success_claim
+
+    assert _review_output_has_forbidden_success_claim(
+        "DomHand click: submitted form for 'Next'. Page navigated to https://example.com/step-2."
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_same_tab_guard_init_failure_aborts_run() -> None:
+    hooks = importlib.import_module("ghosthands.agent.hooks")
+
+    browser = MagicMock()
+    browser._cdp_add_init_script = AsyncMock(side_effect=RuntimeError("CDP rejected same-tab script"))
+    browser.get_pages = AsyncMock()
+    hooks._SAME_TAB_GUARD_INSTALLED.discard(id(browser))
+
+    with pytest.raises(RuntimeError, match="CDP rejected same-tab script"):
+        await hooks.install_same_tab_guard(SimpleNamespace(browser_session=browser))
+
+    browser.get_pages.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_same_tab_guard_current_page_failure_aborts_run() -> None:
+    hooks = importlib.import_module("ghosthands.agent.hooks")
+
+    page = MagicMock()
+    page.evaluate = AsyncMock(side_effect=RuntimeError("page rejected same-tab script"))
+    browser = MagicMock()
+    browser._cdp_add_init_script = AsyncMock()
+    browser.get_pages = AsyncMock(return_value=[page])
+    hooks._SAME_TAB_GUARD_INSTALLED.discard(id(browser))
+
+    with pytest.raises(RuntimeError, match="page rejected same-tab script"):
+        await hooks.install_same_tab_guard(SimpleNamespace(browser_session=browser))
+
+
 def test_multi_checkbox_answer_preserves_every_exact_choice() -> None:
     from ghosthands.actions.views import FormField
     from ghosthands.dom.fill_label_match import _coerce_answer_to_field
@@ -450,6 +536,19 @@ async def test_review_guard_current_page_failure_is_fatal() -> None:
 
     with pytest.raises(RuntimeError, match="page rejected script"):
         await hooks.install_final_submit_guard(SimpleNamespace(browser_session=browser), allow_submit=False)
+
+
+@pytest.mark.asyncio
+async def test_review_guard_block_state_read_failure_is_fatal() -> None:
+    hooks = importlib.import_module("ghosthands.agent.hooks")
+
+    page = MagicMock()
+    page.evaluate = AsyncMock(side_effect=RuntimeError("page rejected guard-state read"))
+    browser = MagicMock()
+    browser.get_current_page = AsyncMock(return_value=page)
+
+    with pytest.raises(RuntimeError, match="page rejected guard-state read"):
+        await hooks.consume_blocked_final_submit(SimpleNamespace(browser_session=browser))
 
 
 def test_completed_review_result_never_claims_submitted_or_applied() -> None:


### PR DESCRIPTION
## Summary
- add review-only VALET terminal/runtime contract
- require exact CDP target ownership and abort on guard failures
- preserve HITL, cost events, and review-ready state without final submission
- harden submit-control detection and repeater save handling

## Verification
- `uv run pytest tests/unit/test_valet_runtime_contract.py tests/integration/test_review_submit_guard.py tests/ci/browser/test_tabs.py tests/unit/test_repeater_commit_js.py -q`
- 62 passed

No external application submission was triggered.